### PR TITLE
Support for Gnome 3.20

### DIFF
--- a/freon@UshakovVasilii_Github.yahoo.com/metadata.json
+++ b/freon@UshakovVasilii_Github.yahoo.com/metadata.json
@@ -1,5 +1,5 @@
 {
-  "shell-version": ["3.12", "3.14", "3.16", "3.18"],
+  "shell-version": ["3.12", "3.14", "3.16", "3.18", "3.20"],
   "uuid": "freon@UshakovVasilii_Github.yahoo.com",
   "name": "Freon",
   "description": "Shows CPU temperature, disk temperature, video card temperature (NVIDIA/Catalyst/Bumblebee&NVIDIA), voltage and fan RPM (forked from xtranophilist/gnome-shell-extension-sensors)",


### PR DESCRIPTION
[Gnome 3.20 was released](https://www.gnome.org/news/2016/03/gnome-3-20-released/) yesterday.
I just tested and this extension works fine under Gnome 3.20!