### PR TITLE
Fix German translation

### DIFF
--- a/freon@UshakovVasilii_Github.yahoo.com/po/de.po
+++ b/freon@UshakovVasilii_Github.yahoo.com/po/de.po
@@ -3,14 +3,14 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2015-10-06 17:05-0300\n"
-"PO-Revision-Date: 2017-06-09 17:39+0200\n"
+"PO-Revision-Date: 2018-08-07 11:27+0200\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Last-Translator: Jonatan Hatakeyama Zeidler <jonatan_zeidler@gmx.de>\n"
+"Last-Translator: Dennis M. Pöpperl <free-software@dm-poepperl.de>\n"
 "Language-Team: \n"
-"X-Generator: Poedit 2.0.1\n"
+"X-Generator: Poedit 2.0.9\n"
 
 #: bumblebeeNvidiaUtil.js:75 prefs.js:82
 msgid "Bumblebee + NVIDIA"
@@ -27,7 +27,7 @@ msgstr "Maximum"
 #: extension.js:341
 #, javascript-format
 msgid "%drpm"
-msgstr "%dupm"
+msgstr "%d1/min"
 
 #: extension.js:350
 #, javascript-format


### PR DESCRIPTION
 "U/min" or "UpM" are no valid translations for "rpm".
 The standardised unit is "1/min".
 See https://de.wikipedia.org/wiki/Rpm_(Einheit).
#91 needs to be fixed, because there is no separation between the number and "1".