### PR TITLE
Correct usage of toString on Uint8Array

### DIFF
--- a/freon@UshakovVasilii_Github.yahoo.com/commandLineUtil.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/commandLineUtil.js
@@ -1,3 +1,4 @@
+const ByteArray = imports.byteArray;
 const Lang = imports.lang;
 const GLib = imports.gi.GLib;
 const Gio = imports.gi.Gio;
@@ -33,13 +34,13 @@ var CommandLineUtil = new Lang.Class({
 
                 while (([line, size] = outReader.read_line(null)) != null && line != null) {
                     if(line)
-                        output.push(line.toString());
+                        output.push(ByteArray.toString(line));
                 }
                 stdout.close(null);
 
                 while (([line, size] = errReader.read_line(null)) != null && line != null) {
                     if(line)
-                        output.push(line.toString());
+                        output.push(ByteArray.toString(line));
                 }
                 stderr.close(null);
 

--- a/freon@UshakovVasilii_Github.yahoo.com/nvidiaUtil.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/nvidiaUtil.js
@@ -1,3 +1,4 @@
+const ByteArray = imports.byteArray;
 const Lang = imports.lang;
 const GLib = imports.gi.GLib;
 const Gio = imports.gi.Gio;
@@ -33,7 +34,7 @@ var NvidiaUtil = new Lang.Class({
                   let [line, size] = [null, 0];
 
                   while (([line, size] = outReader.read_line(null)) != null && line != null) {
-                      let match = /.*\[gpu:[\d]\].*\(([\w\d\ ]+)\).*/.exec(line.toString());
+                      let match = /.*\[gpu:[\d]\].*\(([\w\d\ ]+)\).*/.exec(ByteArray.toString(line));
                       if(match){
                           this._labels.push(match[1]);
                       }


### PR DESCRIPTION
According to warning given today with gnome 3.30:
"Some code called array.toString() on a Uint8Array instance. Previously this would have interpreted the bytes of the array as a string, but that is nonstandard. In the future this will return the bytes as comma-separated digits. For the time being, the old behavior has been preserved, but please fix your code anyway to explicitly call ByteArray.toString(array)."

Fixes the actual fault listed in #98 