### PR TITLE
Installation and other info are already better explained in the wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,4 @@ gnome-shell-extension-freon
 
 Freon is forked from [gnome-shell-extension-sensors](https://github.com/xtranophilist/gnome-shell-extension-sensors). Freon is an extension for displaying CPU temperature, disk temperature, video card temperature (NVIDIA/Catalyst/Bumblebee&NVIDIA), voltage and fan RPM in GNOME Shell.
 
-More info in [wiki](https://github.com/UshakovVasilii/gnome-shell-extension-freon/wiki)
-
-### Installation from git
-
-    git clone https://github.com/UshakovVasilii/gnome-shell-extension-freon.git
-    cd gnome-shell-extension-freon
-    mkdir -p ~/.local/share/gnome-shell/extensions
-    cp -r freon@UshakovVasilii_Github.yahoo.com ~/.local/share/gnome-shell/extensions/.
-restart GNOME Shell (`Alt+F2`, `r`, `Enter`) and enable the extension through gnome-tweak-tool.
-
-### Installation from extensions.gnome.org
-
-https://extensions.gnome.org/extension/841/freon/
+**[For more info, check out the Freon wiki.](https://github.com/UshakovVasilii/gnome-shell-extension-freon/wiki)**


### PR DESCRIPTION
I figure it's better to make the link to the project wiki more prominent
than to replicate only a small part of the wiki here.

I'm open to suggestions about wording and style, if you have any preference.