### PR TITLE
Reword labels for the bottom buttons of the top bar menu

### DIFF
--- a/freon@UshakovVasilii_Github.yahoo.com/extension.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/extension.js
@@ -468,14 +468,14 @@ var FreonMenuButton = new Lang.Class({
         this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
         let wiki = new PopupMenu.PopupBaseMenuItem();
-        wiki.actor.add(new St.Label({ text: _("GitHub / WiKi") }), { expand: true, x_fill: false });
+        wiki.actor.add(new St.Label({ text: _("Go to the Freon wiki") }), { expand: true, x_fill: false });
         wiki.connect('activate', function () {
                             Util.spawn(["xdg-open", "https://github.com/UshakovVasilii/gnome-shell-extension-freon/wiki"]);
         });
         this.menu.addMenuItem(wiki);
 
         let settings = new PopupMenu.PopupBaseMenuItem();
-        settings.actor.add(new St.Label({ text: _("Sensors Settings") }), { expand: true, x_fill: false });
+        settings.actor.add(new St.Label({ text: _("Sensor Settings") }), { expand: true, x_fill: false });
         settings.connect('activate', function () {
             Util.spawn(["gnome-shell-extension-prefs", Me.metadata.uuid]);
         });


### PR DESCRIPTION
I think it makes sense to call it the Freon wiki rather than the GitHub
wiki, because code hosting could change, and this wiki is specifically
all about Freon. And I think adding the "Go to" phrase both clarifies
what the button does, and also sorta invites the user to actually click
on the button.

And as for "Sensors Settings", this might be a little nit-picky, but you
don't *usually* pluralize a noun when it's acting as a modifier on
another noun.