### PR TITLE
Visualize hot (on panel) sensors that became stale

### DIFF
--- a/freon@UshakovVasilii_Github.yahoo.com/extension.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/extension.js
@@ -133,7 +133,7 @@ var FreonMenuButton = new Lang.Class({
             this._menuLayout.add(i);
         }
         let l = new St.Label({
-            text: '\u2026', /* ... */
+            text: '\u26a0',  // ⚠, warning
             y_expand: true,
             y_align: Clutter.ActorAlign.CENTER});
         this._hotLabels[s] = l;
@@ -415,6 +415,9 @@ var FreonMenuButton = new Lang.Class({
             }
 
             this._fixNames(sensors);
+
+            for (let k in this._hotLabels)
+                this._hotLabels[k].set_text('\u26a0');  // ⚠, warning
 
             for (let s of sensors)
                 if(s.type != 'separator') {


### PR DESCRIPTION
When a hwmon module was unloaded or crashed any sensors it had that were
also pinned to the panel (i.e. a 'hot sensor') retained the value
they had last, hiding the failure.

To fix that, this first clears all hot labels, replacing them with a
placeholder, before checking the new sensor data.  The placeholder
chosen is ⚠ (\u26a0 warning sign), after some experimentation with other
alternatives.

For consistency, the placeholder used on initialization is also
changed.

![screenshot from 2019-03-02 17-22-23](https://user-images.githubusercontent.com/1832496/53687461-97aed080-3d13-11e9-8840-416e325ab4c2.png)
