### PR TITLE
Added nvme support through nvme-cli

### DIFF
--- a/freon@UshakovVasilii_Github.yahoo.com/extension.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/extension.js
@@ -17,6 +17,7 @@ const NvidiaUtil = Me.imports.nvidiaUtil;
 const HddtempUtil = Me.imports.hddtempUtil;
 const SensorsUtil = Me.imports.sensorsUtil;
 const smartctlUtil = Me.imports.smartctlUtil;
+const nvmecliUtil = Me.imports.nvmecliUtil;
 const BumblebeeNvidiaUtil = Me.imports.bumblebeeNvidiaUtil;
 const FreonItem = Me.imports.freonItem;
 
@@ -198,6 +199,9 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
                 break;
             case 'smartctl':
                 this._utils.disks = new smartctlUtil.smartctlUtil();
+                break;
+            case 'nvmecli':
+                this._utils.disks = new nvmecliUtil.nvmecliUtil();
                 break;
         }
     }

--- a/freon@UshakovVasilii_Github.yahoo.com/nvmecliUtil.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/nvmecliUtil.js
@@ -1,0 +1,50 @@
+const GLib = imports.gi.GLib;
+
+const Me = imports.misc.extensionUtils.getCurrentExtension();
+
+function getNvmeData (argv){
+    const nvme = GLib.find_program_in_path('nvme')
+    return JSON.parse(GLib.spawn_command_line_sync(`${nvme} ${argv} -o json`)[1].toString())
+}
+
+var nvmecliUtil  = class {
+    constructor(callback) {
+        this._nvmeDevices = [];
+        try {
+            this._nvmeDevices = getNvmeData("list")["Devices"]
+        } catch (e) {
+            global.log('[FREON] Unable to find nvme devices: ' + e);
+        }        
+        this._updated = true;
+    }
+
+    get available(){
+        return this._nvmeDevices.length > 0;
+    }
+
+    get updated (){
+       return this._updated;
+    }
+
+    set updated (updated){
+        this._updated = updated;
+    }
+
+    get temp() {
+        return this._nvmeDevices.map(device => {
+            return {
+                label: device["ModelNumber"],
+                temp: parseFloat(getNvmeData(`smart-log ${device["DevicePath"]}`).temperature) - 273.15    
+            }
+        })
+    }
+
+    destroy(callback) {
+        this._nvmeDevices = [];
+    }
+
+    execute(callback) {
+        this._updated = true;
+    }
+
+};

--- a/freon@UshakovVasilii_Github.yahoo.com/prefs.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/prefs.js
@@ -66,7 +66,7 @@ var FreonPrefsWidget = new GObject.registerClass(class Freon_FreonPrefsWidget ex
             help : _("Works if you have more than three voltage sensors")});
 
         this._addComboBox({
-            items : {none : 'None', hddtemp : 'Hddtemp', udisks2 : 'UDisks2', smartctl : 'smartctl'},
+            items : {none : 'None', hddtemp : 'Hddtemp', udisks2 : 'UDisks2', smartctl : 'smartctl', nvmecli : 'nvme-cli'},
             key: 'drive-utility', y : i, x : 0,
             label: _('HDD/SSD Temperature Utility')
         });


### PR DESCRIPTION
Added [nvme-cli](https://github.com/linux-nvme/nvme-cli) as a new HDD/SDD Temperature Utility in order to display NVMe based SSD temperature as requested on issue #137.

It asumes the current user is able to successfully execute the nvme command line utility.
