### PR TITLE
Set as second extension within `Main.panel._rightBox`

### DIFF
--- a/freon@UshakovVasilii_Github.yahoo.com/extension.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/extension.js
@@ -161,7 +161,7 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
         };
 
         let p = this.positionInPanel;
-        boxes[p].insert_child_at_index(this.container, p == 'right' ? 0 : -1)
+        boxes[p].insert_child_at_index(this.container, p == 'right' ? 1 : -1)
     }
 
     _showIconOnPanelChanged(){


### PR DESCRIPTION
This would leave position 0 free for other extensions which update their content more frequently (eg. NetSpeed) but still let Freon on the most left if you don't use other extensions.