### PR TITLE
Panel box index

### DIFF
--- a/freon@UshakovVasilii_Github.yahoo.com/extension.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/extension.js
@@ -106,6 +106,7 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
         this._addSettingChangedSignal('drive-utility', this._driveUtilityChanged.bind(this));
         this._addSettingChangedSignal('gpu-utility', this._gpuUtilityChanged.bind(this));
         this._addSettingChangedSignal('position-in-panel', this._positionInPanelChanged.bind(this));
+        this._addSettingChangedSignal('panel-box-index', this._positionInPanelChanged.bind(this));
         this._addSettingChangedSignal('group-temperature', this._querySensors.bind(this))
         this._addSettingChangedSignal('group-voltage', this._rerender.bind(this))
 
@@ -161,7 +162,8 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
         };
 
         let p = this.positionInPanel;
-        boxes[p].insert_child_at_index(this.container, p == 'right' ? 0 : -1)
+        let i = this._settings.get_int('panel-box-index');
+        boxes[p].insert_child_at_index(this.container, i);
     }
 
     _showIconOnPanelChanged(){

--- a/freon@UshakovVasilii_Github.yahoo.com/prefs.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/prefs.js
@@ -38,7 +38,7 @@ var FreonPrefsWidget = new GObject.registerClass(class Freon_FreonPrefsWidget ex
 
         this._addComboBox({
             items : {centigrade : "\u00b0C", fahrenheit : "\u00b0F"},
-            key: 'unit', y : i++, x : 2,
+            key: 'unit', y : i++, x : 3,
             label: _('Temperature Unit')
         });
 
@@ -48,20 +48,20 @@ var FreonPrefsWidget = new GObject.registerClass(class Freon_FreonPrefsWidget ex
             label: _('Position in Panel')
         });
 
-        this._addSwitch({key : 'show-icon-on-panel', y : i++, x : 2,
+        this._addSwitch({key : 'show-icon-on-panel', y : i++, x : 3,
             label : _('Show Icon on Panel')});
 
         this._addSwitch({key : 'show-fan-rpm', y : i, x : 0,
             label : _('Show Fan Speed')});
 
-        this._addSwitch({key : 'show-voltage', y : i++, x : 2,
+        this._addSwitch({key : 'show-voltage', y : i++, x : 3,
             label : _('Show Power Supply Voltage')});
 
         this._addSwitch({key : 'group-temperature', y : i, x : 0,
             label : _('Group Temperature Items'),
             help : _("Works if you have more than three temperature sensors")});
 
-        this._addSwitch({key : 'group-voltage', y : i++, x : 2,
+        this._addSwitch({key : 'group-voltage', y : i++, x : 3,
             label : _('Group Voltage Items'),
             help : _("Works if you have more than three voltage sensors")});
 
@@ -77,7 +77,7 @@ var FreonPrefsWidget = new GObject.registerClass(class Freon_FreonPrefsWidget ex
                 'nvidia-settings' : _('NVIDIA'),
                 'aticonfig' : _('Catalyst'),
                 'bumblebee-nvidia-smi': _('Bumblebee + NVIDIA') },
-            key: 'gpu-utility', y : i, x : 2,
+            key: 'gpu-utility', y : i, x : 3,
             label: _('Video Card Temperature Utility')
         });
     }

--- a/freon@UshakovVasilii_Github.yahoo.com/prefs.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/prefs.js
@@ -48,6 +48,10 @@ var FreonPrefsWidget = new GObject.registerClass(class Freon_FreonPrefsWidget ex
             label: _('Position in Panel')
         });
 
+        let panelBoxIndex = Gtk.SpinButton.new_with_range (-1, 20, 1);
+        this.attach(panelBoxIndex, 2, i, 1, 1);
+        this._settings.bind('panel-box-index', panelBoxIndex, 'value', Gio.SettingsBindFlags.DEFAULT);
+
         this._addSwitch({key : 'show-icon-on-panel', y : i++, x : 3,
             label : _('Show Icon on Panel')});
 

--- a/freon@UshakovVasilii_Github.yahoo.com/schemas/org.gnome.shell.extensions.sensors.gschema.xml
+++ b/freon@UshakovVasilii_Github.yahoo.com/schemas/org.gnome.shell.extensions.sensors.gschema.xml
@@ -63,6 +63,12 @@
       <description>Position in Panel ('left', 'center', 'right')</description>
     </key>
 
+    <key name="panel-box-index" type="i">
+      <default>0</default>
+      <summary>Index in panel box</summary>
+      <description>Index within the selected panel box (0: first, 1: second, ..., -1: last)</description>
+    </key>
+
     <key type="b" name="group-temperature">
       <default>true</default>
       <summary>Group temperature menu items</summary>


### PR DESCRIPTION
Let the user to chose where to place the extension button within each panel box.

From the left (with default orientation, otherwise from the right) as:
- 0, first
- 1, second
- ...
- -1, last