### PR TITLE
Enable extension at the right index

### DIFF
--- a/freon@UshakovVasilii_Github.yahoo.com/extension.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/extension.js
@@ -635,8 +635,8 @@ function init(extensionMeta) {
 
 function enable() {
     freonMenu = new FreonMenuButton();
-    let positionInPanel = freonMenu.positionInPanel;
-    Main.panel.addToStatusArea('freonMenu', freonMenu, positionInPanel == 'right' ? 0 : -1, positionInPanel);
+    Main.panel.addToStatusArea('freonMenu', freonMenu);
+    freonMenu._positionInPanelChanged();
 }
 
 function disable() {


### PR DESCRIPTION
Bug: enabling does spawn the extension at wrong index.

Fix: update the position when enabling.