### PR TITLE
Fix issues with GNOME 3.4

### DIFF
--- a/freon@UshakovVasilii_Github.yahoo.com/freonItem.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/freonItem.js
@@ -1,10 +1,11 @@
-const St = imports.gi.St;
+const GObject = imports.gi.GObject;
 const PopupMenu = imports.ui.popupMenu;
+const St = imports.gi.St;
 
-var FreonItem = class extends PopupMenu.PopupBaseMenuItem {
+var FreonItem = GObject.registerClass(class FreonItem extends PopupMenu.PopupBaseMenuItem {
 
-    constructor(gIcon, key, label, value, displayName) {
-        super();
+    _init(gIcon, key, label, value, displayName) {
+        super._init();
         this._main = false;
         this._key = key;
         this._gIcon = gIcon;
@@ -43,4 +44,4 @@ var FreonItem = class extends PopupMenu.PopupBaseMenuItem {
     set value(value) {
         this._valueLabel.text = value;
     }
-};
+});


### PR DESCRIPTION
GNOME/gjs@72062b5e0368 ("object: Throw if constructing an unregistered object inheriting from GObject") started to enforce proper GObject inheritance through registerClass:

> When a class inherits from a GObject class, it must be always registered using GObject.registerClass, however gjs was accepting this silently [...]

Closes: #146 ("Broken on 3.34")  
See also: [GNOME/gjs/doc/Mapping.md]

[GNOME/gjs/doc/Mapping.md]: https://gitlab.gnome.org/GNOME/gjs/blob/57ba26807271a9b4fdd0f4bb5a8c9bad776d98d4/doc/Mapping.md