### PR TITLE
Remove deprecated use of Actor.actor

### DIFF
--- a/freon@UshakovVasilii_Github.yahoo.com/extension.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/extension.js
@@ -93,7 +93,7 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
             this._createInitialIcon();
         }
 
-        this.actor.add_actor(this._menuLayout);
+        this.add_actor(this._menuLayout);
 
         this._settingChangedSignals = [];
         this._addSettingChangedSignal('update-time', this._updateTimeChanged.bind(this));


### PR DESCRIPTION
In Gnome 3.34 accessing `<object>.actor` results in a warning:

```
Usage of object.actor is deprecated for Freon_FreonMenuButton
get@resource:///org/gnome/shell/ui/environment.js:249:29
_init@[...]/freon@UshakovVasilii_Github.yahoo.com/extension.js:96:9
enable@[...]/freon@UshakovVasilii_Github.yahoo.com/extension.js:637:17
_callExtensionEnable@resource:///org/gnome/shell/ui/extensionSystem.js:148:13
loadExtension@resource:///org/gnome/shell/ui/extensionSystem.js:280:21
_loadExtensions/<@resource:///org/gnome/shell/ui/extensionSystem.js:490:13
collectFromDatadirs@resource:///org/gnome/shell/misc/fileUtils.js:27:17
_loadExtensions@resource:///org/gnome/shell/ui/extensionSystem.js:469:9
_enableAllExtensions@resource:///org/gnome/shell/ui/extensionSystem.js:499:13
_sessionUpdated@resource:///org/gnome/shell/ui/extensionSystem.js:530:13
init@resource:///org/gnome/shell/ui/extensionSystem.js:48:9
_initializeUI@resource:///org/gnome/shell/ui/main.js:242:5
start@resource:///org/gnome/shell/ui/main.js:138:5
@<main>:1:31
```

The `actor` property is no longer needed, as `Freon_FreonMenuButton` already
is an Actor.

Additionally, we only support old Gnome versions on the Freon versions of the
same era, so we do not need to worry about backwards compatibility (see #153).

Reported-by: @49studebaker
Fixes: #156 ("JS WARNING: " [...])
Related: https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/487 ("this.actor = this removal")