### PR TITLE
Switch to `gnome-extensions prefs` on Gnome Shell 3.36

### DIFF
--- a/freon@UshakovVasilii_Github.yahoo.com/extension.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/extension.js
@@ -487,7 +487,7 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
         let settings = new PopupMenu.PopupBaseMenuItem();
         settings.actor.add(new St.Label({ text: _("Sensor Settings") }), { expand: true, x_fill: false });
         settings.connect('activate', function () {
-            Util.spawn(["gnome-shell-extension-prefs", Me.metadata.uuid]);
+            Util.spawn(["gnome-extensions", "prefs", Me.metadata.uuid]);
         });
         this.menu.addMenuItem(settings);
     }

--- a/freon@UshakovVasilii_Github.yahoo.com/metadata.json
+++ b/freon@UshakovVasilii_Github.yahoo.com/metadata.json
@@ -1,5 +1,5 @@
 {
-  "shell-version": ["3.34"],
+  "shell-version": ["3.36"],
   "uuid": "freon@UshakovVasilii_Github.yahoo.com",
   "name": "Freon",
   "description": "Shows CPU temperature, disk temperature, video card temperature (NVIDIA/Catalyst/Bumblebee&NVIDIA), voltage and fan RPM (forked from xtranophilist/gnome-shell-extension-sensors)",


### PR DESCRIPTION
On Gnome 3.36 `gnome-shell-extension-prefs` might not be installed by default.