### PR TITLE
Update to 3.37.90 (3.38)

### DIFF
--- a/freon@UshakovVasilii_Github.yahoo.com/extension.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/extension.js
@@ -483,14 +483,14 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
         this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
         let wiki = new PopupMenu.PopupBaseMenuItem();
-        wiki.actor.add(new St.Label({ text: _("Go to the Freon wiki") }), { expand: true, x_fill: false });
+        wiki.actor.add_child(new St.Label({ text: _("Go to the Freon wiki"), x_align: Clutter.ActorAlign.CENTER, x_expand: true }));
         wiki.connect('activate', function () {
                             Util.spawn(["xdg-open", "https://github.com/UshakovVasilii/gnome-shell-extension-freon/wiki"]);
         });
         this.menu.addMenuItem(wiki);
 
         let settings = new PopupMenu.PopupBaseMenuItem();
-        settings.actor.add(new St.Label({ text: _("Sensor Settings") }), { expand: true, x_fill: false });
+        settings.actor.add_child(new St.Label({ text: _("Sensor Settings"), x_align: Clutter.ActorAlign.CENTER, x_expand: true }));
         settings.connect('activate', function () {
             Util.spawn(["gnome-extensions", "prefs", Me.metadata.uuid]);
         });


### PR DESCRIPTION
BoxLayout meta child (expand/align) properties have long been depracated and recently fully removed in gnome shell 3.37.2 (!1274), in favor of ClutterActor's ones.

Embrace the change to provide compatibility with upcoming gnome shell 3.38 release