### PR TITLE
Only parse the JSON from sensors once

### DIFF
--- a/freon@UshakovVasilii_Github.yahoo.com/commandLineUtil.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/commandLineUtil.js
@@ -26,8 +26,8 @@ var CommandLineUtil = class {
                 } catch (e) {
                     logError(e);
                 } finally {
-                    this._updated = true;
                     callback();
+                    this._updated = true;
                 }
             });
         } catch(e){


### PR DESCRIPTION
Parse the output from `sensors -A -j` once in a callback to `execute()`, instead of for every `temp()`, `rpm()`, etc. call.

As the callback is now used to process data, also move the toggling of `this._updated` (in `CommandLineUtil.execute()`) to after the callback has completed.