### PR TITLE
remove redeclaration of _onDestroy()

### DIFF
--- a/freon@UshakovVasilii_Github.yahoo.com/extension.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/extension.js
@@ -111,7 +111,7 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
         this._addSettingChangedSignal('group-temperature', this._querySensors.bind(this))
         this._addSettingChangedSignal('group-voltage', this._rerender.bind(this))
 
-        this.connect('destroy', this._onDestroy.bind(this));
+        this.connect('destroy', this._onButtonDestroy.bind(this));
 
         // don't postprone the first call by update-time.
         this._querySensors();
@@ -264,7 +264,7 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
         this._settingChangedSignals.push(this._settings.connect('changed::' + key, callback));
     }
 
-    _onDestroy(){
+    _onButtonDestroy(){
         this._destroyDriveUtility();
         this._destroyGpuUtility();
         Mainloop.source_remove(this._timeoutId);


### PR DESCRIPTION
_onDestroy() is already present in panelMenu.Button

https://github.com/GNOME/gnome-shell/blob/e6089c83e2993098814b7056e1c7f54e5dc06820/js/ui/panelMenu.js#L187

So this function is called twice. Put log("### something") into it to check. And proper Button._onDestroy() is not called at all. This leads to shell crash on screen lock.

Also spaming ~15 lines in journal on extension disable:
```
Source ID 2374 was not found when attempting to remove it
../../../gobject/gsignal.c:2641: instance '0x7f5880132080' has no handler with id '43421'
```
I'm not shure which solution is better... Mybe adding super._onDestroy() and removing connection to 'destroy' signal is more propper... But proposed renaming is simple and tested and works ok.