### PR TITLE
Ease GNOME shell version in metadata.json

### DIFF
--- a/freon@UshakovVasilii_Github.yahoo.com/metadata.json
+++ b/freon@UshakovVasilii_Github.yahoo.com/metadata.json
@@ -1,5 +1,5 @@
 {
-  "shell-version": ["40.0"],
+  "shell-version": ["40"],
   "uuid": "freon@UshakovVasilii_Github.yahoo.com",
   "name": "Freon",
   "description": "Shows CPU temperature, disk temperature, video card temperature (NVIDIA/Catalyst/Bumblebee&NVIDIA), voltage and fan RPM (forked from xtranophilist/gnome-shell-extension-sensors)",


### PR DESCRIPTION
With `40.0`, the extensions is incorrectly listed as incompatible with GNOME versions `40.x` (see screenshot).

![image](https://user-images.githubusercontent.com/6129517/119279591-4e980f00-bbf2-11eb-9cfa-b38aa3abe0c2.png)

There are no breaking changes from 40.0 to 40.1. The next _big release_  of GNOME will be 41, then 42 and so on.

To [quote](https://discourse.gnome.org/t/new-gnome-versioning-scheme/4235):
> Followed by the first stable release, 40.0. Every subsequent stable release will increment the minor component by 1, so:
>
> 40.1, 40.2, 40.3, …
> After the 40.0 release in March 2021, the next version of GNOME will be 41, and will follow the exact same pattern.