### PR TITLE
Left align Pop-up menu items

### DIFF
--- a/freon@UshakovVasilii_Github.yahoo.com/extension.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/extension.js
@@ -483,14 +483,14 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
         this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
         let wiki = new PopupMenu.PopupBaseMenuItem();
-        wiki.actor.add_child(new St.Label({ text: _("Go to the Freon wiki"), x_align: Clutter.ActorAlign.CENTER, x_expand: true }));
+        wiki.actor.add_child(new St.Label({ text: _("Go to the Freon wiki"), x_align: Clutter.ActorAlign.START, x_expand: true }));
         wiki.connect('activate', function () {
                             Util.spawn(["xdg-open", "https://github.com/UshakovVasilii/gnome-shell-extension-freon/wiki"]);
         });
         this.menu.addMenuItem(wiki);
 
         let settings = new PopupMenu.PopupBaseMenuItem();
-        settings.actor.add_child(new St.Label({ text: _("Sensor Settings"), x_align: Clutter.ActorAlign.CENTER, x_expand: true }));
+        settings.actor.add_child(new St.Label({ text: _("Sensor Settings"), x_align: Clutter.ActorAlign.START, x_expand: true }));
         settings.connect('activate', function () {
             Util.spawn(["gnome-extensions", "prefs", Me.metadata.uuid]);
         });

--- a/freon@UshakovVasilii_Github.yahoo.com/freonItem.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/freonItem.js
@@ -11,7 +11,7 @@ var FreonItem = GObject.registerClass(class FreonItem extends PopupMenu.PopupBas
         this._key = key;
         this._gIcon = gIcon;
 
-        this._labelActor = new St.Label({text: displayName ? displayName : label, x_align: Clutter.ActorAlign.CENTER, x_expand: true});
+        this._labelActor = new St.Label({text: displayName ? displayName : label, x_align: Clutter.ActorAlign.START, x_expand: true});
         this.actor.add(new St.Icon({ style_class: 'popup-menu-icon', gicon : gIcon}));
         this.actor.add_child(this._labelActor);
         this._valueLabel = new St.Label({text: value});


### PR DESCRIPTION
Some time back, all labels were centered.
However, this doesn't fit well with the overall GNOME shell styling and other popup menus. Not only that, it looks weird in certain scenarios (screenshot below).

This pull requests makes the labels left aligned which is more consistent with the GNOME shell and other popup menus.

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/6129517/119552059-ec5d1c80-bd5f-11eb-89ec-b5c9040dc060.png) | ![image](https://user-images.githubusercontent.com/6129517/119552563-4958d280-bd60-11eb-8408-80e2fe19ebf0.png) |
