### PR TITLE
sensorsUtil: read nvme sensors as disk temperature sensors

### DIFF
--- a/freon@UshakovVasilii_Github.yahoo.com/sensorsUtil.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/sensorsUtil.js
@@ -71,7 +71,7 @@ var SensorsUtil = class extends CommandLineUtil.CommandLineUtil {
             if (!data.hasOwnProperty(chipset) || (gpuFamily != gpuFilter.test(chipset) && tempType))
                 continue;
 
-            let diskFilter = /(drivetemp)/;
+            let diskFilter = /(drivetemp|nvme)/;
             let diskFamily = (sensorFamily === 'disk')
             if (!data.hasOwnProperty(chipset) || (diskFamily != diskFilter.test(chipset) && tempType))
                 continue;


### PR DESCRIPTION
Extend e8848c2baabf ("sensorsUtil: read drivetemp sensors as disk temperature sensors (#217)") to also identify NVMe temperature sensors.