### PR TITLE
freeipmiUtil: implement IPMI reading using ipmi-sensors from FreeIPMI project

### DIFF
--- a/freon@UshakovVasilii_Github.yahoo.com/freeipmiUtil.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/freeipmiUtil.js
@@ -1,0 +1,100 @@
+const GLib = imports.gi.GLib;
+
+const Me = imports.misc.extensionUtils.getCurrentExtension();
+const CommandLineUtil = Me.imports.commandLineUtil;
+
+var FreeipmiUtil = class extends CommandLineUtil.CommandLineUtil {
+    constructor() {
+        super();
+
+        const path = GLib.find_program_in_path('ipmi-sensors');
+        // --comma-separated-output: pseudo csv output format, splitting on comma may be good enough for the values we read.
+        this._argv = path ? [path, '--comma-separated-output'] : null;
+
+        if (this._argv) {
+            const ExtensionUtils = imports.misc.extensionUtils;
+            const Me = ExtensionUtils.getCurrentExtension();
+            if (ExtensionUtils.getSettings().get_string('method-ipmi-utility') === 'sudo')
+            {
+                const sudo_path = GLib.find_program_in_path('sudo');
+                // --non-interactive: do not ask for password, return if no permission.
+                this._argv = sudo_path ? [sudo_path, '--non-interactive'].concat(this._argv) : null;
+            }
+        }
+    }
+
+    // Avoid parsing the data more than once.
+    execute(callback) {
+        super.execute(() => {
+            let data = [];
+
+            for (const line of this._output) {
+                if (!line)
+                    continue;
+
+                const value_list = line.split(',');
+
+                if (value_list.length <= 1)
+                    break;
+
+                const id = value_list[0];
+
+                if (id === 'ID')
+                    continue;
+
+                const name = value_list[1];
+                const value = value_list[3];
+                const unit = value_list[4];
+
+                if (value !== 'N/A' && unit !== 'N/A') {
+                    data[name] = {};
+                    data[name]["value"] = value;
+                    data[name]["unit"] = unit;
+                }
+            }
+
+            this._data = data;
+            callback();
+        });
+    }
+
+    get temp() {
+        return this._parseSensorsOutput(/^(C|C per minute)$/, 'temp');
+    }
+
+    get rpm() {
+        return this._parseSensorsOutput(/^RPM$/, 'rpm');
+    }
+
+    get volt() {
+        return this._parseSensorsOutput(/^V$/, 'volt');
+    }
+
+  _parseSensorsOutput(sensorFilter, sensorType) {
+        if(!this._data)
+            return [];
+
+        const data = this._data;
+
+        let sensors = [];
+        for (const name in data) {
+            if (!data.hasOwnProperty(name))
+                continue;
+
+            const value = data[name]["value"]
+            const unit = data[name]["unit"]
+
+            if (!sensorFilter.test(unit))
+                continue;
+
+            const feature = {
+                label: name,
+                [sensorType]: parseFloat(value)
+            };
+
+            sensors.push(feature);
+        }
+
+        return sensors;
+    }
+};

--- a/freon@UshakovVasilii_Github.yahoo.com/prefs.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/prefs.js
@@ -88,9 +88,26 @@ var FreonPrefsWidget = new GObject.registerClass(class Freon_FreonPrefsWidget ex
             label: _('Video Card Temperature Utility')
         });
 
+        this._addComboBox({
+            items : {
+                'none' : _('None'),
+                'freeipmi' : _('FreeIPMI') },
+            key: 'ipmi-utility', y : i, x : 0,
+            label: _('IPMI Sensors Utility')
+        });
+
+        this._addComboBox({
+            items : {
+                'direct' : 'Direct',
+                'sudo' : 'sudo' },
+            key: 'method-ipmi-utility', y : i, x : 1,
+            label: ''
+        });
+
         this._addSwitch({key : 'show-liquidctl', y : i++, x : 3,
             label : _('Show liquidctl Sensors'),
             help : _('Show data from liquidctl v1.7.0 or later')});
+
     }
 
     _addSwitch(params){

--- a/freon@UshakovVasilii_Github.yahoo.com/schemas/org.gnome.shell.extensions.sensors.gschema.xml
+++ b/freon@UshakovVasilii_Github.yahoo.com/schemas/org.gnome.shell.extensions.sensors.gschema.xml
@@ -63,6 +63,18 @@
       <description>Utility for detect video card temperature ('none', 'nvidia-settings' or 'aticonfig')</description>
     </key>
 
+    <key type="s" name="ipmi-utility">
+      <default>'none'</default>
+      <summary>Utility for reading IPMI sensors</summary>
+      <description>Utility reading IPMI sensors ('none', 'freeipmi')</description>
+    </key>
+
+    <key type="s" name="method-ipmi-utility">
+      <default>'direct'</default>
+      <summary>Method to run IPMI utility</summary>
+      <description>Method to run IPMI utility</description>
+    </key>
+
     <key type="b" name="show-liquidctl">
       <default>false</default>
       <summary>Show liquidctl sensors</summary>


### PR DESCRIPTION
It is currently fully functional but I mark it as draft because I don't know what to do with the sudo part.

This sensor provider works as soon as I add this to `/etc/sudoers.d/ipmi-sensors` on my end:

```
illwieckz	ALL=(root)	NOPASSWD:	/usr/sbin/ipmi-sensors
```

Then the extension calls `ipmi-sensors` with `sudo` with a `--non-interactive` option to not ask user password if permission is not given (it just not provides anything if permission is missing).

Note that the same question comes with existing `smartctl` provider which is usually not runable by user.

What do you think about this sudo part, do you have any better idea, should I do a PR for smartctl to do it the same way?

IPMI disabled:

[![Freon FreeIPMI](https://dl.illwieckz.net/b/gnome-shell-extension-freon/shots/20211118-112050-001.freon-ipmi.png)](https://dl.illwieckz.net/b/gnome-shell-extension-freon/shots/20211118-112050-001.freon-ipmi.png)

IPMI enabled:

[![Freon FreeIPMI](https://dl.illwieckz.net/b/gnome-shell-extension-freon/shots/20211118-112056-001.freon-ipmi.png)](https://dl.illwieckz.net/b/gnome-shell-extension-freon/shots/20211118-112056-001.freon-ipmi.png)