### PR TITLE
prefs: revamp the preference window and make various providers selectable independently, ref #223

### DIFF
--- a/freon@UshakovVasilii_Github.yahoo.com/extension.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/extension.js
@@ -11,14 +11,14 @@ const GObject = imports.gi.GObject;
 
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
-const UDisks2 = Me.imports.udisks2;
+const UDisks2Util = Me.imports.udisks2;
 const AticonfigUtil = Me.imports.aticonfigUtil;
 const NvidiaUtil = Me.imports.nvidiaUtil;
 const HddtempUtil = Me.imports.hddtempUtil;
 const SensorsUtil = Me.imports.sensorsUtil;
-const liquidctlUtil = Me.imports.liquidctlUtil;
-const smartctlUtil = Me.imports.smartctlUtil;
-const nvmecliUtil = Me.imports.nvmecliUtil;
+const LiquidctlUtil = Me.imports.liquidctlUtil;
+const SmartctlUtil = Me.imports.smartctlUtil;
+const NvmecliUtil = Me.imports.nvmecliUtil;
 const BumblebeeNvidiaUtil = Me.imports.bumblebeeNvidiaUtil;
 const FreonItem = Me.imports.freonItem;
 
@@ -64,12 +64,19 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
 
         this._sensorMenuItems = {};
 
-        this._utils = {
-            sensors: new SensorsUtil.SensorsUtil()
-        };
-        this._initDriveUtility();
-        this._initGpuUtility();
+        this._utils = {};
+
+        this._initSensorsUtility();
         this._initLiquidctlUtility();
+
+        this._initNvidiaUtility();
+        this._initBumblebeeNvidiaUtility();
+        this._initAticonfigUtility();
+
+        this._initUdisks2Utility();
+        this._initHddtempUtility();
+        this._initSmartctlUtility();
+        this._initNvmecliUtility();
 
         let temperatureIcon = Gio.icon_new_for_string(Me.path + '/icons/material-icons/material-temperature-symbolic.svg');
         this._sensorIcons = {
@@ -98,20 +105,39 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
         this.add_actor(this._menuLayout);
 
         this._settingChangedSignals = [];
-        this._addSettingChangedSignal('update-time', this._updateTimeChanged.bind(this));
-        this._addSettingChangedSignal('unit', this._querySensors.bind(this));
-        this._addSettingChangedSignal('show-degrees-on-panel', this._updateUI.bind(this));
-        this._addSettingChangedSignal('show-icon-on-panel', this._showIconOnPanelChanged.bind(this));
+
         this._addSettingChangedSignal('hot-sensors', this._querySensors.bind(this));
-        this._addSettingChangedSignal('show-decimal-value', this._querySensors.bind(this));
-        this._addSettingChangedSignal('show-fan-rpm', this._querySensors.bind(this));
-        this._addSettingChangedSignal('show-voltage', this._querySensors.bind(this));
-        this._addSettingChangedSignal('drive-utility', this._driveUtilityChanged.bind(this));
-        this._addSettingChangedSignal('gpu-utility', this._gpuUtilityChanged.bind(this));
-        this._addSettingChangedSignal('show-liquidctl', this._liquidctlUtilityChanged.bind(this));
+
+        this._addSettingChangedSignal('update-time', this._updateTimeChanged.bind(this));
         this._addSettingChangedSignal('position-in-panel', this._positionInPanelChanged.bind(this));
         this._addSettingChangedSignal('panel-box-index', this._positionInPanelChanged.bind(this));
-        this._addSettingChangedSignal('group-temperature', this._querySensors.bind(this))
+        this._addSettingChangedSignal('show-icon-on-panel', this._showIconOnPanelChanged.bind(this));
+
+        this._addSettingChangedSignal('show-degrees-on-panel', this._updateUI.bind(this));
+        this._addSettingChangedSignal('unit', this._querySensors.bind(this));
+        this._addSettingChangedSignal('show-rpm-on-panel', this._updateUI.bind(this));
+        this._addSettingChangedSignal('show-volts-on-panel', this._updateUI.bind(this));
+
+        this._addSettingChangedSignal('show-decimal-value', this._querySensors.bind(this));
+
+        this._addSettingChangedSignal('use-generic-lmsensors', this._sensorsUtilityChanged.bind(this));
+        this._addSettingChangedSignal('use-generic-liquidctl', this._liquidctlUtilityChanged.bind(this));
+
+        this._addSettingChangedSignal('use-gpu-nvidia', this._nvidiaUtilityChanged.bind(this));
+        this._addSettingChangedSignal('use-gpu-nvidiabumblebee', this._nvidiabumblebeeUtilityChanged.bind(this));
+        this._addSettingChangedSignal('use-gpu-aticonfig', this._aticonfigUtilityChanged.bind(this));
+
+        this._addSettingChangedSignal('use-drive-udisks2', this._udisks2UtilityChanged.bind(this));
+        this._addSettingChangedSignal('use-drive-hddtemp', this._hddtempUtilityChanged.bind(this));
+        this._addSettingChangedSignal('use-drive-smartctl', this._smartctlUtilityChanged.bind(this));
+        this._addSettingChangedSignal('use-drive-nvmecli', this._nvmecliUtilityChanged.bind(this));
+
+        this._addSettingChangedSignal('show-temperature', this._rerender.bind(this));
+        this._addSettingChangedSignal('show-fan-rpm', this._rerender.bind(this));
+        this._addSettingChangedSignal('show-voltage', this._rerender.bind(this));
+
+        this._addSettingChangedSignal('group-temperature', this._rerender.bind(this))
+        this._addSettingChangedSignal('group-rpm', this._rerender.bind(this))
         this._addSettingChangedSignal('group-voltage', this._rerender.bind(this))
 
         this.connect('destroy', this._onButtonDestroy.bind(this));
@@ -191,68 +217,28 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
             this._hotLabels[l].set_style_class_name(showIcon ? 'freon-panel-icon-label' : 'freon-panel-no-icon-label');
     }
 
-    _driveUtilityChanged(){
-        this._destroyDriveUtility();
-        this._initDriveUtility();
+    _initSensorsUtility() {
+        if (this._settings.get_boolean('use-generic-lmsensors'))
+            this._utils.sensors = new SensorsUtil.SensorsUtil();
+    }
+
+    _destroySensorsUtility() {
+        if (this._utils.sensors) {
+            this._utils.sensors.destroy();
+            delete this._utils.sensors;
+        }
+    }
+
+    _sensorsUtilityChanged() {
+        this._destroySensorsUtility();
+        this._initSensorsUtility();
         this._querySensors();
-    }
-
-    _initDriveUtility(){
-        switch(this._settings.get_string('drive-utility')){
-            case 'hddtemp':
-                this._utils.disks = new HddtempUtil.HddtempUtil();
-                break;
-            case 'udisks2':
-                this._utils.disks = new UDisks2.UDisks2(() => {
-                    // this._updateDisplay(); we cannot change actor in background thread #74
-                });
-                break;
-            case 'smartctl':
-                this._utils.disks = new smartctlUtil.smartctlUtil();
-                break;
-            case 'nvmecli':
-                this._utils.disks = new nvmecliUtil.nvmecliUtil();
-                break;
-        }
-    }
-
-    _destroyDriveUtility(){
-        if(this._utils.disks){
-            this._utils.disks.destroy();
-            delete this._utils.disks;
-        }
-    }
-
-    _initGpuUtility(){
-        switch(this._settings.get_string('gpu-utility')){
-            case 'nvidia-settings':
-                this._utils.gpu = new NvidiaUtil.NvidiaUtil();
-                break;
-            case 'aticonfig':
-                this._utils.gpu = new AticonfigUtil.AticonfigUtil();
-                break;
-            case 'bumblebee-nvidia-smi':
-                this._utils.gpu = new BumblebeeNvidiaUtil.BumblebeeNvidiaUtil();
-                break;
-        }
-    }
-
-    _destroyGpuUtility(){
-        if(this._utils.gpu){
-            this._utils.gpu.destroy();
-            delete this._utils.gpu;
-        }
-    }
-
-    _gpuUtilityChanged(){
-        this._destroyGpuUtility();
-        this._initGpuUtility();
-        this._querySensors();
+        this._updateUI(true);
     }
 
     _initLiquidctlUtility() {
-        if (this._settings.get_boolean('show-liquidctl'))
-            this._utils.liquidctl = new liquidctlUtil.LiquidctlUtil();
+        if (this._settings.get_boolean('use-generic-liquidctl'))
+            this._utils.liquidctl = new LiquidctlUtil.LiquidctlUtil();
     }
 
     _destroyLiquidctlUtility() {
@@ -266,6 +252,142 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
         this._destroyLiquidctlUtility();
         this._initLiquidctlUtility();
         this._querySensors();
+        this._updateUI(true);
+    }
+
+    _initNvidiaUtility() {
+        if (this._settings.get_boolean('use-gpu-nvidia'))
+            this._utils.nvidia = new NvidiaUtil.NvidiaUtil();
+    }
+
+    _destroyNvidiaUtility() {
+        if (this._utils.nvidia) {
+            this._utils.nvidia.destroy();
+            delete this._utils.nvidia;
+        }
+    }
+
+    _nvidiaUtilityChanged() {
+        this._destroyNvidiaUtility();
+        this._initNvidiaUtility();
+        this._querySensors();
+        this._updateUI(true);
+    }
+
+    _initBumblebeeNvidiaUtility() {
+        if (this._settings.get_boolean('use-gpu-bumblebeenvidia'))
+            this._utils.nvidiabumblebee = new BumblebeeNvidiaUtil.BumblebeeNvidiaUtil();
+    }
+
+    _destroyBumblebeeNvidiaUtility() {
+        if (this._utils.nvidiabumblebee) {
+            this._utils.nvidiabumblebee.destroy();
+            delete this._utils.nvidiabumblebee;
+        }
+    }
+
+    _nvidiabumblebeeUtilityChanged() {
+        this._destroyBumblebeeNvidiaUtility();
+        this._initBumblebeeNvidiaUtility();
+        this._querySensors();
+        this._updateUI(true);
+    }
+
+    _initAticonfigUtility() {
+        if (this._settings.get_boolean('use-gpu-aticonfig'))
+            this._utils.aticonfig = new AticonfigUtil.AticonfigUtil();
+    }
+
+    _destroyAticonfigUtility() {
+        if (this._utils.aticonfig) {
+            this._utils.aticonfig.destroy();
+            delete this._utils.aticonfig;
+        }
+    }
+
+    _aticonfigUtilityChanged() {
+        this._destroyAticonfigUtility();
+        this._initAticonfigUtility();
+        this._querySensors();
+        this._updateUI(true);
+    }
+
+    _initUdisks2Utility() {
+        if (this._settings.get_boolean('use-drive-udisks2'))
+            this._utils.udisks2 = new UDisks2Util.UDisks2(() => {
+                 // this._updateDisplay(); we cannot change actor in background thread #74
+             });
+    }
+
+    _destroyUdisks2Utility() {
+        if (this._utils.udisks2) {
+            this._utils.udisks2.destroy();
+            delete this._utils.udisks2;
+        }
+    }
+
+    _udisks2UtilityChanged() {
+        this._destroyUdisks2Utility();
+        this._initUdisks2Utility();
+        this._querySensors();
+        this._updateUI(true);
+    }
+
+    _initHddtempUtility() {
+        if (this._settings.get_boolean('use-drive-hddtemp'))
+            this._utils.hddtemp = new HddtempUtil.HddtempUtil();
+    }
+
+    _destroyHddtempUtility() {
+        if (this._utils.hddtemp) {
+            this._utils.hddtemp.destroy();
+            delete this._utils.hddtemp;
+        }
+    }
+
+    _hddtempUtilityChanged() {
+        this._destroyHddtempUtility();
+        this._initHddtempUtility();
+        this._querySensors();
+        this._updateUI(true);
+    }
+
+    _initSmartctlUtility() {
+        if (this._settings.get_boolean('use-drive-smartctl'))
+            this._utils.smartctl = new SmartctlUtil.SmartctlUtil();
+    }
+
+    _destroySmartctlUtility() {
+        if (this._utils.smartctl) {
+            this._utils.smartctl.destroy();
+            delete this._utils.smartctl;
+        }
+    }
+
+    _smartctlUtilityChanged() {
+        this._destroySmartctlUtility();
+        this._initSmartctlUtility();
+        this._querySensors();
+        this._updateUI(true);
+    }
+
+    _initNvmecliUtility() {
+        if (this._settings.get_boolean('use-drive-nvmecli'))
+            this._utils.nvmecli = new NvmecliUtil.NvmecliUtil();
+    }
+
+    _destroyNvmecliUtility() {
+        if (this._utils.nvmecli) {
+            this._utils.nvmecli.destroy();
+            delete this._utils.nvmecli;
+        }
+    }
+
+    _nvmecliUtilityChanged() {
+        this._destroyNvmecliUtility();
+        this._initNvmecliUtility();
+        this._querySensors();
+        this._updateUI(true);
     }
 
     _updateTimeChanged(){
@@ -343,33 +465,61 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
     }
 
     _updateDisplay(){
-        let gpuTempInfo = this._utils.sensors.gpu;
-
-        if (this._utils.gpu && this._utils.gpu.available)
-            gpuTempInfo = gpuTempInfo.concat(this._utils.gpu.temp);
-
-        let sensorsTempInfo = this._utils.sensors.temp;
-
+        let sensorsTempInfo = [];
+        let gpuTempInfo = []
+        let driveTempInfo = [];
         let fanInfo = [];
-        if (this._settings.get_boolean('show-fan-rpm'))
-            fanInfo = this._utils.sensors.rpm;
-
         let voltageInfo = [];
-        if (this._settings.get_boolean('show-voltage'))
-            voltageInfo = this._utils.sensors.volt;
 
-        let driveTempInfo = this._utils.sensors.disks;
-        if(this._utils.disks && this._utils.disks.available) {
-            driveTempInfo = driveTempInfo.concat(this._utils.disks.temp);
+        if (this._utils.sensors && this._utils.sensors.available) {
+            if (this._settings.get_boolean('show-temperature')) {
+                sensorsTempInfo = sensorsTempInfo.concat(this._utils.sensors.temp);
+                gpuTempInfo = gpuTempInfo.concat(this._utils.sensors.gpu);
+                driveTempInfo = driveTempInfo.concat(this._utils.sensors.disks);
+            }
+
+            if (this._settings.get_boolean('show-fan-rpm'))
+                fanInfo = fanInfo.concat(this._utils.sensors.rpm);
+            if (this._settings.get_boolean('show-voltage'))
+                voltageInfo = voltageInfo.concat(this._utils.sensors.volt);
         }
 
         if (this._utils.liquidctl && this._utils.liquidctl.available) {
-            sensorsTempInfo = sensorsTempInfo.concat(this._utils.liquidctl.temp);
+            if (this._settings.get_boolean('show-temperature'))
+                sensorsTempInfo = sensorsTempInfo.concat(this._utils.liquidctl.temp);
             if (this._settings.get_boolean('show-fan-rpm'))
                 fanInfo = fanInfo.concat(this._utils.liquidctl.rpm);
             if (this._settings.get_boolean('show-voltage'))
                 voltageInfo = voltageInfo.concat(this._utils.liquidctl.volt);
         }
+
+        if (this._utils.nvidia && this._utils.nvidia.available)
+            if (this._settings.get_boolean('show-temperature'))
+                gpuTempInfo = gpuTempInfo.concat(this._utils.nvidia.temp);
+
+        if (this._utils.bumblebeenvidia && this._utils.bumblebeenvidia.available)
+            if (this._settings.get_boolean('show-temperature'))
+                gpuTempInfo = gpuTempInfo.concat(this._utils.bumblebeenvidia.temp);
+
+        if (this._utils.aticonfig && this._utils.aticonfig.available)
+            if (this._settings.get_boolean('show-temperature'))
+                gpuTempInfo = gpuTempInfo.concat(this._utils.aticonfig.temp);
+
+        if (this._utils.udisks2 && this._utils.udisks2.available)
+            if (this._settings.get_boolean('show-temperature'))
+                driveTempInfo = driveTempInfo.concat(this._utils.udisks2.temp);
+
+        if (this._utils.hddtemp && this._utils.hddtemp.available)
+            if (this._settings.get_boolean('show-temperature'))
+                driveTempInfo = driveTempInfo.concat(this._utils.hddtemp.temp);
+
+        if (this._utils.smartctl && this._utils.smartctl.available)
+            if (this._settings.get_boolean('show-temperature'))
+                driveTempInfo = driveTempInfo.concat(this._utils.smartctl.temp);
+
+        if (this._utils.nvmecli && this._utils.nvmecli.available)
+            if (this._settings.get_boolean('show-temperature'))
+                driveTempInfo = driveTempInfo.concat(this._utils.nvmecli.temp);
 
         sensorsTempInfo.sort(function(a,b) { return a.label.localeCompare(b.label) });
         driveTempInfo.sort(function(a,b) { return a.label.localeCompare(b.label) });
@@ -378,7 +528,26 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
 
         let tempInfo = gpuTempInfo.concat(sensorsTempInfo).concat(driveTempInfo);
 
-        if (tempInfo.length > 0){
+        if (tempInfo.length == 0
+            && fanInfo.length == 0
+            && voltageInfo.length == 0) {
+            this._sensorMenuItems = {};
+            this.menu.removeAll();
+
+            let item = new PopupMenu.PopupMenuItem(
+                this._utils.sensors && this._utils.sensors.available
+                    ? _("Please run sensors-detect as root.")
+                    : _("Please install lm_sensors.\nIf this doesn\'t help, click here to report with your sensors output!")
+            );
+            item.connect('activate',function() {
+                Util.spawn(["xdg-open", "https://github.com/UshakovVasilii/gnome-shell-extension-freon/wiki/Dependency"]);
+            });
+            this.menu.addMenuItem(item);
+            this._appendStaticMenuItems();
+
+            for (let k in this._hotLabels)
+                this._hotLabels[k].set_text('\u26a0');  // ⚠, warning
+        } else {
             let total = 0;
             let sum = 0;
             let max = 0;
@@ -400,9 +569,11 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
                     value: this._formatTemp(i.temp),
                     displayName: i.displayName});
             }
+
             for (let i of sensorsTempInfo){
                 sensors.push({type:'temperature', label: i.label, value:this._formatTemp(i.temp)});
             }
+
             for (let i of driveTempInfo){
                 sensors.push({type:'drive-temperature', label: i.label, value:this._formatTemp(i.temp)});
             }
@@ -436,20 +607,24 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
             }
 
             for (let fan of fanInfo){
+                const unit = this._settings.get_boolean('show-rpm-on-panel') ? 'rpm': '';
+
                 sensors.push({
-                    type:'fan',
-                    label:fan.label,
-                    value:_("%drpm").format(fan.rpm)});
+                    type: 'fan',
+                    label: fan.label,
+                    value: _("%d%s").format(fan.rpm, unit)});
             }
             if (fanInfo.length > 0 && voltageInfo.length > 0){
                 sensors.push({type : 'separator'});
             }
             for (let voltage of voltageInfo){
+                const unit = this._settings.get_boolean('show-volts-on-panel') ? 'V': '';
+
                 sensors.push({
                     type : 'voltage',
-                    label:voltage.label,
-                    value:_("%s%.2fV").format(((voltage.volt >= 0) ? '+' : ''),
-                    voltage.volt)});
+                    label: voltage.label,
+                    value: _("%s%.2f%s").format(((voltage.volt >= 0) ? '+' : ''),
+                    voltage.volt, unit)});
             }
 
             this._fixNames(sensors);
@@ -491,20 +666,6 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
                 this.menu.removeAll();
                 this._appendMenuItems(sensors);
             }
-        } else {
-            this._sensorMenuItems = {};
-            this.menu.removeAll();
-
-            let item = new PopupMenu.PopupMenuItem(
-                this._utils.sensors.available
-                    ? _("Please run sensors-detect as root.")
-                    : _("Please install lm_sensors.\nIf this doesn\'t help, click here to report with your sensors output!")
-            );
-            item.connect('activate',function() {
-                Util.spawn(["xdg-open", "https://github.com/UshakovVasilii/gnome-shell-extension-freon/wiki/Dependency"]);
-            });
-            this.menu.addMenuItem(item);
-            this._appendStaticMenuItems();
         }
     }
 
@@ -531,7 +692,17 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
         this._lastSensorsCount = sensors.length;
         this._sensorMenuItems = {};
         let needGroupTemperature = this._settings.get_boolean('group-temperature');
+        let needGroupRpm = this._settings.get_boolean('group-rpm');
         let needGroupVoltage = this._settings.get_boolean('group-voltage');
+
+        if(needGroupRpm){
+            let i = 0;
+            for (let s of sensors)
+                if(s.type == 'fan')
+                    i++;
+            if(i < 2)
+                needGroupRpm = false;
+        }
 
         if(needGroupVoltage){
             let i = 0;
@@ -543,6 +714,7 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
         }
 
         let temperatureGroup = null;
+        let rpmGroup = null;
         let voltageGroup = null;
 
         for (let s of sensors){
@@ -623,6 +795,13 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
                         this.menu.addMenuItem(temperatureGroup);
                     }
                     temperatureGroup.menu.addMenuItem(item);
+                } else if(needGroupVoltage && s.type == 'fan') {
+                    if(!fanGroup) {
+                        fanGroup = new PopupMenu.PopupSubMenuMenuItem(_('Fan Speed'), true);
+                        fanGroup.icon.gicon = this._sensorIcons['fan'];
+                        this.menu.addMenuItem(fanGroup);
+                    }
+                    fanGroup.menu.addMenuItem(item);
                 } else if(needGroupVoltage && s.type == 'voltage') {
                     if(!voltageGroup) {
                         voltageGroup = new PopupMenu.PopupSubMenuMenuItem(_('Voltage'), true);

--- a/freon@UshakovVasilii_Github.yahoo.com/nvmecliUtil.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/nvmecliUtil.js
@@ -7,7 +7,7 @@ function getNvmeData (argv){
     return JSON.parse(GLib.spawn_command_line_sync(`${nvme} ${argv} -o json`)[1].toString())
 }
 
-var nvmecliUtil  = class {
+var NvmecliUtil  = class {
     constructor(callback) {
         this._nvmeDevices = [];
         try {

--- a/freon@UshakovVasilii_Github.yahoo.com/prefs.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/prefs.js
@@ -26,82 +26,161 @@ var FreonPrefsWidget = new GObject.registerClass(class Freon_FreonPrefsWidget ex
         this._settings = ExtensionUtils.getSettings();
 
         let i = 0;
+        let j = 0;
 
-        this.attach(new Gtk.Label({ label: _('Poll Sensors Every (sec)'), halign : Gtk.Align.END}), 0, i, 1, 1);
-        let updateTime = Gtk.SpinButton.new_with_range (1, 60, 1);
-        this.attach(updateTime, 1, i++, 1, 1);
-        this._settings.bind('update-time', updateTime, 'value', Gio.SettingsBindFlags.DEFAULT);
-
-        this._addSwitch({key : 'show-decimal-value', y : i, x : 0,
-            label : _('Show Decimal Value'),
-            help : _("Show one digit after decimal")});
-
-        this._addComboBox({
-            items : {centigrade : "\u00b0C", fahrenheit : "\u00b0F"},
-            key: 'unit', y : i++, x : 3,
-            label: _('Temperature Unit')
+        this._addLabel({
+            label: _('Display Options'),
+            y : i++, x : j
         });
 
+        this._addLabel({
+            label: _('Poll Sensors Every (sec)'),
+            y : i, x : j
+        });
+
+        let updateTime = Gtk.SpinButton.new_with_range (1, 60, 1);
+        this.attach(updateTime, j + 1, i++, 1, 1);
+        this._settings.bind('update-time', updateTime, 'value', Gio.SettingsBindFlags.DEFAULT);
+
         this._addComboBox({
+            label: _('Position in Panel'),
             items : {left : _('Left'), center : _('Center'), right : _('Right')},
-            key: 'position-in-panel', y : i, x : 0,
-            label: _('Position in Panel')
+            key: 'position-in-panel', y : i++, x : j
+        });
+
+        this._addLabel({
+            label: _('Index in Panel'),
+            y : i, x : j
         });
 
         let panelBoxIndex = Gtk.SpinButton.new_with_range (-1, 20, 1);
-        this.attach(panelBoxIndex, 2, i, 1, 1);
+        this.attach(panelBoxIndex, j + 1, i++, 1, 1);
         this._settings.bind('panel-box-index', panelBoxIndex, 'value', Gio.SettingsBindFlags.DEFAULT);
 
-        this._addSwitch({key : 'show-degrees-on-panel', y : i++, x : 3,
-            label : _('Show \u00b0C/\u00b0F on Panel')});
+        this._addSwitch({key : 'show-icon-on-panel', y : i++, x : j,
+            label : _('Show Icon')});
 
-        this._addSwitch({key : 'show-icon-on-panel', y : i++, x : 3,
-            label : _('Show Icon on Panel')});
+        this._addComboBox({
+            label: 'Temperature Unit',
+            items : {centigrade : "\u00b0C", fahrenheit : "\u00b0F"},
+            key: 'unit', y : i++, x : j
+        });
 
-        this._addSwitch({key : 'show-fan-rpm', y : i, x : 0,
-            label : _('Show Fan Speed')});
+        this._addSwitch({key : 'show-degrees-on-panel', y : i++, x : j,
+            label : _('Show Temperature Unit')});
 
-        this._addSwitch({key : 'show-voltage', y : i++, x : 3,
-            label : _('Show Power Supply Voltage')});
+        this._addSwitch({key : 'show-rpm-on-panel', y : i++, x : j,
+            label : _('Show Fan Speed Unit')});
 
-        this._addSwitch({key : 'group-temperature', y : i, x : 0,
-            label : _('Group Temperature Items'),
+        this._addSwitch({key : 'show-volts-on-panel', y : i++, x : j,
+            label : _('Show Voltage Unit')});
+
+        this._addSwitch({key : 'show-decimal-value', y : i++, x : j,
+            label : _('Show Decimal Value'),
+            help : _("Show one digit after decimal")});
+
+        i = 0;
+        j = 3;
+
+        this._addLabel({
+            label: _('Generic sensors'),
+            y : i++, x : j
+        });
+
+        this._addSwitch({key : 'use-generic-lmsensors', y : i++, x : j,
+            label : 'lm-sensors',
+            help : _('Read sensors using sensors from lm-sensors')});
+
+        this._addSwitch({key : 'use-generic-liquidctl', y : i++, x : j,
+            label : 'liquidctl',
+            help : _('Read sensors using liquidctl v1.7.0 or later')});
+
+        this._addLabel({
+            label: _('GPU sensors'),
+            y : i++, x : j
+        });
+
+        this._addSwitch({key : 'use-gpu-nvidia', y : i++, x : j,
+            label : 'Nvidia'});
+
+        this._addSwitch({key : 'use-gpu-bumblebeenvidia', y : i++, x : j,
+            label : 'Bumblebee + Nvidia'});
+
+        this._addSwitch({key : 'use-gpu-aticonfig', y : i++, x : j,
+            label : 'Catalyst'});
+
+        this._addLabel({
+            label: _('Drive sensors'),
+            y : i++, x : j
+        });
+
+        this._addSwitch({key : 'use-drive-udisks2', y : i++, x : j,
+            label : 'Udisks2'});
+
+        this._addSwitch({key : 'use-drive-hddtemp', y : i++, x : j,
+            label : 'Hddtemp'});
+
+        this._addSwitch({key : 'use-drive-smartctl', y : i++, x : j,
+            label : 'smartctl',
+            help : _('Read drive sensors from smartctl from smartmontools')});
+
+        this._addSwitch({key : 'use-drive-nvmecli', y : i++, x : j,
+            label : 'nvme-cli'});
+
+        i = 0;
+        j = 6;
+
+        this._addLabel({
+            label: _('Show Sensors'),
+            y : i++, x : j
+        });
+
+        this._addSwitch({key : 'show-temperature', y : i++, x : j,
+            label : _('Temperature')});
+
+        this._addSwitch({key : 'show-fan-rpm', y : i++, x : j,
+            label : _('Fan Speed')});
+
+        this._addSwitch({key : 'show-voltage', y : i++, x : j,
+            label : _('Voltage')});
+
+        this._addLabel({
+            label: _('Group Items'),
+            y : i++, x : j
+        });
+
+        this._addSwitch({key : 'group-temperature', y : i++, x : j,
+            label : _('Temperature'),
             help : _("Works if you have more than three temperature sensors")});
 
-        this._addSwitch({key : 'group-voltage', y : i++, x : 3,
-            label : _('Group Voltage Items'),
+        this._addSwitch({key : 'group-rpm', y : i++, x : j,
+            label : _('Fan speed'),
+            help : _("Works if you have more than three fan speed sensors")});
+
+        this._addSwitch({key : 'group-voltage', y : i++, x : j,
+            label : _('Voltage'),
             help : _("Works if you have more than three voltage sensors")});
+    }
 
-        this._addComboBox({
-            items : {none : _('None'), hddtemp : 'Hddtemp', udisks2 : 'UDisks2', smartctl : 'smartctl', nvmecli : 'nvme-cli'},
-            key: 'drive-utility', y : i, x : 0,
-            label: _('HDD/SSD Temperature Utility')
-        });
+    _addLabel(params){
+        let lbl = new Gtk.Label({label: params.label,halign : Gtk.Align.END});
+        this.attach(lbl, params.x, params.y, 1, 1);
 
-        this._addComboBox({
-            items : {
-                'none' : _('None'),
-                'nvidia-settings' : _('NVIDIA'),
-                'aticonfig' : _('Catalyst'),
-                'bumblebee-nvidia-smi': _('Bumblebee + NVIDIA') },
-            key: 'gpu-utility', y : i++, x : 3,
-            label: _('Video Card Temperature Utility')
-        });
-
-        this._addSwitch({key : 'show-liquidctl', y : i++, x : 3,
-            label : _('Show liquidctl Sensors'),
-            help : _('Show data from liquidctl v1.7.0 or later')});
+        if(params.help){
+            lbl.set_tooltip_text(params.help);
+        }
     }
 
     _addSwitch(params){
-        let lbl = new Gtk.Label({label: params.label,halign : Gtk.Align.END});
-        this.attach(lbl, params.x, params.y, 1, 1);
+        this._addLabel(params);
+
         let sw = new Gtk.Switch({halign : Gtk.Align.END, valign : Gtk.Align.CENTER});
         this.attach(sw, params.x + 1, params.y, 1, 1);
+
         if(params.help){
-            lbl.set_tooltip_text(params.help);
             sw.set_tooltip_text(params.help);
         }
+
         this._settings.bind(params.key, sw, 'active', Gio.SettingsBindFlags.DEFAULT);
     }
 
@@ -127,7 +206,8 @@ var FreonPrefsWidget = new GObject.registerClass(class Freon_FreonPrefsWidget ex
             this._settings.set_string(params.key, model.get_value(iter, 0))
         });
 
-        this.attach(new Gtk.Label({ label: params.label, halign : Gtk.Align.END}), params.x, params.y, 1, 1);
+        this._addLabel(params);
+
         this.attach(combobox, params.x + 1, params.y, 1, 1);
     }
 });

--- a/freon@UshakovVasilii_Github.yahoo.com/schemas/org.gnome.shell.extensions.sensors.gschema.xml
+++ b/freon@UshakovVasilii_Github.yahoo.com/schemas/org.gnome.shell.extensions.sensors.gschema.xml
@@ -3,70 +3,16 @@
 
   <schema id="org.gnome.shell.extensions.freon" path="/org/gnome/shell/extensions/freon/">
 
-    <key type="i" name="update-time">
-      <default>5</default>
-      <summary>Seconds before next update</summary>
-      <description>This is the seconds after CPU temperature extension updates the data from the syetem</description>
-    </key>
-
-    <key type="s" name="unit">
-      <default>'centigrade'</default>
-      <summary>Unit</summary>
-      <description>The unit ('centigrade' or 'fahrenheit') the extension should display the temperature in</description>
-    </key>
-    
-    <key type="b" name="show-degrees-on-panel">
-      <default>true</default>
-      <summary>Show degrees celsius/fahrenheit on Panel</summary>
-      <description>Show degrees celsius/fahrenheit on Panel</description>
-    </key>
-
-    <key type="b" name="show-icon-on-panel">
-      <default>true</default>
-      <summary>Show Icon on Panel</summary>
-      <description>Show sensor icon on top panel</description>
-    </key>
-
     <key name="hot-sensors" type="as">
       <default>["__average__", "__max__"]</default>
       <summary>Sensors to show in panel</summary>
       <description>Select the sensord whose values has to be shown in the panel</description>
     </key>
 
-    <key type="b" name="show-decimal-value">
-      <default>false</default>
-      <summary>Show decimal value</summary>
-      <description>Show one digit after decimal</description>
-    </key>
-
-    <key type="b" name="show-fan-rpm">
-      <default>true</default>
-      <summary>Display Fan RPM</summary>
-      <description>Display fan rotation per minute</description>
-    </key>
-
-    <key type="b" name="show-voltage">
-      <default>true</default>
-      <summary>Display voltage</summary>
-      <description>Display voltage of various components</description>
-    </key>
-
-    <key type="s" name="drive-utility">
-      <default>'udisks2'</default>
-      <summary>Utility for detect HDD/SSD temperature</summary>
-      <description>Utility for detect HDD/SSD temperature ('none', 'hddtemp' or 'udisks2')</description>
-    </key>
-
-    <key type="s" name="gpu-utility">
-      <default>'none'</default>
-      <summary>Utility for detect video card temperature</summary>
-      <description>Utility for detect video card temperature ('none', 'nvidia-settings' or 'aticonfig')</description>
-    </key>
-
-    <key type="b" name="show-liquidctl">
-      <default>false</default>
-      <summary>Show liquidctl sensors</summary>
-      <description>Show data from liquidctl v1.7.0 or later</description>
+    <key type="i" name="update-time">
+      <default>5</default>
+      <summary>Seconds before next update</summary>
+      <description>This is the seconds after CPU temperature extension updates the data from the syetem</description>
     </key>
 
     <key type="s" name="position-in-panel">
@@ -81,10 +27,124 @@
       <description>Index within the selected panel box (0: first, 1: second, ..., -1: last)</description>
     </key>
 
+    <key type="b" name="show-icon-on-panel">
+      <default>true</default>
+      <summary>Show Icon on Panel</summary>
+      <description>Show sensor icon on top panel</description>
+    </key>
+
+    <key type="b" name="show-temperature">
+      <default>true</default>
+      <summary>Display Temperature</summary>
+      <description>Display temperature</description>
+    </key>
+
+    <key type="s" name="unit">
+      <default>'centigrade'</default>
+      <summary>Unit</summary>
+      <description>The unit ('centigrade' or 'fahrenheit') the extension should display the temperature in</description>
+    </key>
+
+    <key type="b" name="show-degrees-on-panel">
+      <default>true</default>
+      <summary>Show degrees celsius/fahrenheit on Panel</summary>
+      <description>Show degrees celsius/fahrenheit on Panel</description>
+    </key>
+
+    <key type="b" name="show-rpm-on-panel">
+      <default>true</default>
+      <summary>Show RPM on Panel</summary>
+      <description>Show RPM on Panel</description>
+    </key>
+
+    <key type="b" name="show-volts-on-panel">
+      <default>true</default>
+      <summary>Show volts on Panel</summary>
+      <description>Show volts on Panel</description>
+    </key>
+
+    <key type="b" name="show-decimal-value">
+      <default>false</default>
+      <summary>Show decimal value</summary>
+      <description>Show one digit after decimal</description>
+    </key>
+
+    <key type="b" name="use-generic-lmsensors">
+      <default>true</default>
+      <summary>Read sensors using lm-sensors</summary>
+      <description>Read sensors using sensors from lm-sensors</description>
+    </key>
+
+    <key type="b" name="use-generic-liquidctl">
+      <default>false</default>
+      <summary>Read sensors using liquidctl</summary>
+      <description>Read sensors using liquidctl v1.7.0 or later</description>
+    </key>
+
+    <key type="b" name="use-gpu-nvidia">
+      <default>false</default>
+      <summary>Read GPU sensors from NVidia driver</summary>
+      <description>Read GPU sensors from NVidia driver</description>
+    </key>
+
+    <key type="b" name="use-gpu-bumblebeenvidia">
+      <default>false</default>
+      <summary>Read GPU sensors from Bumblebee + NVidia driver</summary>
+      <description>Read GPU sensors from Bumblebee + NVidia driver</description>
+    </key>
+
+    <key type="b" name="use-gpu-aticonfig">
+      <default>false</default>
+      <summary>Read GPU sensors from Catalyst driver</summary>
+      <description>Read GPU sensors from Catalyst driver</description>
+    </key>
+
+    <key type="b" name="use-drive-udisks2">
+      <default>false</default>
+      <summary>Read drive sensors from Udisks2</summary>
+      <description>Read drive sensors from Udisks2</description>
+    </key>
+
+    <key type="b" name="use-drive-hddtemp">
+      <default>false</default>
+      <summary>Read drive sensors using Hddtemp</summary>
+      <description>Read drive sensors using Hddtemp</description>
+    </key>
+
+    <key type="b" name="use-drive-smartctl">
+      <default>false</default>
+      <summary>Read drive sensors using smartctl</summary>
+      <description>Read drive sensors using smartctl from smartmontool</description>
+    </key>
+
+    <key type="b" name="use-drive-nvmecli">
+      <default>false</default>
+      <summary>Read drive sensors using nvme-cli</summary>
+      <description>Read drive sensors using nvme-cli</description>
+    </key>
+
+    <key type="b" name="show-fan-rpm">
+      <default>true</default>
+      <summary>Display Fan RPM</summary>
+      <description>Display fan rotation per minute</description>
+    </key>
+
+    <key type="b" name="show-voltage">
+      <default>true</default>
+      <summary>Display voltage</summary>
+      <description>Display voltage of various components</description>
+    </key>
+
     <key type="b" name="group-temperature">
       <default>true</default>
       <summary>Group temperature menu items</summary>
       <description>Group more than three sensors temperature menu items</description>
+    </key>
+
+    <key type="b" name="group-rpm">
+      <default>true</default>
+      <summary>Group Fan speed menu items</summary>
+      <description>Group more than three fan speed menu items</description>
     </key>
 
     <key type="b" name="group-voltage">

--- a/freon@UshakovVasilii_Github.yahoo.com/smartctlUtil.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/smartctlUtil.js
@@ -7,7 +7,7 @@ function getSmartData (argv){
     return JSON.parse(ByteArray.toString( GLib.spawn_command_line_sync(`'${smartctl}' ${argv} -j`)[1] ))
 }
 
-var smartctlUtil  = class {
+var SmartctlUtil  = class {
     constructor(callback) {
         this._smartDevices = [];
         try {


### PR DESCRIPTION
This PR revamps the preference window and make various providers selectable independently, see #223.

In the process, I made some columns to try to group options in some meaningful manner, and added some labels. I'm not a GTK wizard so others may do some patches after that to make it look better (like weighting the titles or adding visible column lines), but at least it's a good start.

I also:

- added a group for fan speeds (not only temperature and voltage),
- made V and rpm unit hide-able (not only temperature unit),
- fixed an issue where the message telling to install lm-sensors was displayed when no temperature was reported, even if there was fan speed and/or voltage sensors,
- made lm-sensors disableable, for example someone may only want to monitor Udisks2 or (future) IPMI,
- fixed various bugs were disabling the last source of sensors did not updated the panel,
- and some other things like that.

I can't test fan and voltage groups without IPMI because I don't have enough sensors otherwise.

Sorry for the screenshot mixing French and English language, I don't know if it's possible to render an GNOME Shell extension in one language when the whole desktop uses another language:

[![Freon: revamped preferences](https://dl.illwieckz.net/b/gnome-shell-extension-freon/shots/20211119-215908-000.freon-proposed-prefs.png)](https://dl.illwieckz.net/b/gnome-shell-extension-freon/shots/20211119-215908-000.freon-proposed-prefs.png)