### PR TITLE
prefs: revamp the preference window and make various providers selectable independently, ref #223

### DIFF
--- a/freon@UshakovVasilii_Github.yahoo.com/extension.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/extension.js
@@ -11,17 +11,21 @@ const GObject = imports.gi.GObject;
 
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
-const UDisks2 = Me.imports.udisks2;
-const AticonfigUtil = Me.imports.aticonfigUtil;
-const NvidiaUtil = Me.imports.nvidiaUtil;
-const HddtempUtil = Me.imports.hddtempUtil;
-const SensorsUtil = Me.imports.sensorsUtil;
-const liquidctlUtil = Me.imports.liquidctlUtil;
-const smartctlUtil = Me.imports.smartctlUtil;
-const nvmecliUtil = Me.imports.nvmecliUtil;
-const BumblebeeNvidiaUtil = Me.imports.bumblebeeNvidiaUtil;
-const FreeipmiUtil = Me.imports.freeipmiUtil;
-const FreonItem = Me.imports.freonItem;
+
+const SensorsUtil = Me.imports.sensorsUtil.SensorsUtil;
+const FreeipmiUtil = Me.imports.freeipmiUtil.FreeipmiUtil;
+const LiquidctlUtil = Me.imports.liquidctlUtil.LiquidctlUtil;
+
+const NvidiaUtil = Me.imports.nvidiaUtil.NvidiaUtil;
+const BumblebeeNvidiaUtil = Me.imports.bumblebeeNvidiaUtil.BumblebeeNvidiaUtil;
+const AticonfigUtil = Me.imports.aticonfigUtil.AtiConfigUtil;
+
+const Udisks2Util = Me.imports.udisks2.UDisks2;
+const HddtempUtil = Me.imports.hddtempUtil.HddtempUtil;
+const SmartctlUtil = Me.imports.smartctlUtil.SmartctlUtil;
+const NvmecliUtil = Me.imports.nvmecliUtil.NvmecliUtil;
+
+const FreonItem = Me.imports.freonItem.FreonItem;
 
 const Gettext = imports.gettext.domain(Me.metadata['gettext-domain']);
 const _ = Gettext.gettext;
@@ -65,16 +69,23 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
 
         this._sensorMenuItems = {};
 
-        this._utils = {
-            sensors: new SensorsUtil.SensorsUtil()
-        };
+        this._utils = {};
 
-        this._initDriveUtility();
-        this._initGpuUtility();
-        this._initIpmiUtility();
+        this._initSensorsUtility();
+        this._initFreeipmiUtility();
         this._initLiquidctlUtility();
 
+        this._initNvidiaUtility();
+        this._initBumblebeeNvidiaUtility();
+        this._initAticonfigUtility();
+
+        this._initUdisks2Utility();
+        this._initHddtempUtility();
+        this._initSmartctlUtility();
+        this._initNvmecliUtility();
+
         let temperatureIcon = Gio.icon_new_for_string(Me.path + '/icons/material-icons/material-temperature-symbolic.svg');
+
         this._sensorIcons = {
             'temperature' : temperatureIcon,
             'temperature-average' : temperatureIcon,
@@ -86,10 +97,13 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
         }
 
         this._menuLayout = new St.BoxLayout();
+
         this._hotLabels = {};
         this._hotIcons = {};
+
         let hotSensors = this._settings.get_strv('hot-sensors');
         let showIcon = this._settings.get_boolean('show-icon-on-panel');
+
         for (let s of hotSensors){
             this._createHotItem(s, showIcon);
         }
@@ -101,22 +115,41 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
         this.add_actor(this._menuLayout);
 
         this._settingChangedSignals = [];
-        this._addSettingChangedSignal('update-time', this._updateTimeChanged.bind(this));
-        this._addSettingChangedSignal('unit', this._querySensors.bind(this));
-        this._addSettingChangedSignal('show-degrees-on-panel', this._updateUI.bind(this));
-        this._addSettingChangedSignal('show-icon-on-panel', this._showIconOnPanelChanged.bind(this));
+
         this._addSettingChangedSignal('hot-sensors', this._querySensors.bind(this));
-        this._addSettingChangedSignal('show-decimal-value', this._querySensors.bind(this));
-        this._addSettingChangedSignal('show-fan-rpm', this._querySensors.bind(this));
-        this._addSettingChangedSignal('show-voltage', this._querySensors.bind(this));
-        this._addSettingChangedSignal('drive-utility', this._driveUtilityChanged.bind(this));
-        this._addSettingChangedSignal('gpu-utility', this._gpuUtilityChanged.bind(this));
-        this._addSettingChangedSignal('ipmi-utility', this._ipmiUtilityChanged.bind(this));
-        this._addSettingChangedSignal('method-ipmi-utility', this._ipmiUtilityChanged.bind(this));
-        this._addSettingChangedSignal('show-liquidctl', this._liquidctlUtilityChanged.bind(this));
+
+        this._addSettingChangedSignal('update-time', this._updateTimeChanged.bind(this));
         this._addSettingChangedSignal('position-in-panel', this._positionInPanelChanged.bind(this));
         this._addSettingChangedSignal('panel-box-index', this._positionInPanelChanged.bind(this));
-        this._addSettingChangedSignal('group-temperature', this._querySensors.bind(this))
+        this._addSettingChangedSignal('show-icon-on-panel', this._showIconOnPanelChanged.bind(this));
+
+        this._addSettingChangedSignal('show-temperature-unit', this._updateUI.bind(this));
+        this._addSettingChangedSignal('unit', this._querySensors.bind(this));
+        this._addSettingChangedSignal('show-rotationrate-unit', this._updateUI.bind(this));
+        this._addSettingChangedSignal('show-voltage-unit', this._updateUI.bind(this));
+
+        this._addSettingChangedSignal('show-decimal-value', this._querySensors.bind(this));
+
+        this._addSettingChangedSignal('use-generic-lmsensors', this._sensorsUtilityChanged.bind(this));
+        this._addSettingChangedSignal('use-generic-freeipmi', this._freeipmiUtilityChanged.bind(this));
+        this._addSettingChangedSignal('exec-method-freeipmi', this._freeipmiUtilityChanged.bind(this));
+        this._addSettingChangedSignal('use-generic-liquidctl', this._liquidctlUtilityChanged.bind(this));
+
+        this._addSettingChangedSignal('use-gpu-nvidia', this._nvidiaUtilityChanged.bind(this));
+        this._addSettingChangedSignal('use-gpu-nvidiabumblebee', this._nvidiabumblebeeUtilityChanged.bind(this));
+        this._addSettingChangedSignal('use-gpu-aticonfig', this._aticonfigUtilityChanged.bind(this));
+
+        this._addSettingChangedSignal('use-drive-udisks2', this._udisks2UtilityChanged.bind(this));
+        this._addSettingChangedSignal('use-drive-hddtemp', this._hddtempUtilityChanged.bind(this));
+        this._addSettingChangedSignal('use-drive-smartctl', this._smartctlUtilityChanged.bind(this));
+        this._addSettingChangedSignal('use-drive-nvmecli', this._nvmecliUtilityChanged.bind(this));
+
+        this._addSettingChangedSignal('show-temperature', this._rerender.bind(this));
+        this._addSettingChangedSignal('show-rotationrate', this._rerender.bind(this));
+        this._addSettingChangedSignal('show-voltage', this._rerender.bind(this));
+
+        this._addSettingChangedSignal('group-temperature', this._rerender.bind(this))
+        this._addSettingChangedSignal('group-rotationrate', this._rerender.bind(this))
         this._addSettingChangedSignal('group-voltage', this._rerender.bind(this))
 
         this.connect('destroy', this._onButtonDestroy.bind(this));
@@ -137,8 +170,10 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
         if(showIcon){
             let i = new St.Icon({ style_class: 'system-status-icon'});
             this._hotIcons[s] = i;
+
             if(gicon)
                 i.gicon = gicon;
+
             this._menuLayout.add(i);
         }
         let l = new St.Label({
@@ -146,6 +181,7 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
             y_expand: true,
             y_align: Clutter.ActorAlign.CENTER});
         l.set_style_class_name(showIcon ? 'freon-panel-icon-label' : 'freon-panel-no-icon-label');
+
         this._hotLabels[s] = l;
         this._menuLayout.add(l);
     }
@@ -196,89 +232,47 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
             this._hotLabels[l].set_style_class_name(showIcon ? 'freon-panel-icon-label' : 'freon-panel-no-icon-label');
     }
 
-    _driveUtilityChanged(){
-        this._destroyDriveUtility();
-        this._initDriveUtility();
+    _initSensorsUtility() {
+        if (this._settings.get_boolean('use-generic-lmsensors'))
+            this._utils.sensors = new SensorsUtil();
+    }
+
+    _destroySensorsUtility() {
+        if (this._utils.sensors) {
+            this._utils.sensors.destroy();
+            delete this._utils.sensors;
+        }
+    }
+
+    _sensorsUtilityChanged() {
+        this._destroySensorsUtility();
+        this._initSensorsUtility();
         this._querySensors();
+        this._updateUI(true);
     }
 
-    _initDriveUtility(){
-        switch(this._settings.get_string('drive-utility')){
-            case 'hddtemp':
-                this._utils.disks = new HddtempUtil.HddtempUtil();
-                break;
-            case 'udisks2':
-                this._utils.disks = new UDisks2.UDisks2(() => {
-                    // this._updateDisplay(); we cannot change actor in background thread #74
-                });
-                break;
-            case 'smartctl':
-                this._utils.disks = new smartctlUtil.smartctlUtil();
-                break;
-            case 'nvmecli':
-                this._utils.disks = new nvmecliUtil.nvmecliUtil();
-                break;
+    _initFreeipmiUtility() {
+        if (this._settings.get_boolean('use-generic-freeipmi'))
+            this._utils.freeipmi = new FreeipmiUtil();
+    }
+
+    _destroyFreeipmiUtility() {
+        if(this._utils.freeipmi) {
+            this._utils.freeipmi.destroy();
+            delete this._utils.freeipmi;
         }
     }
 
-    _destroyDriveUtility(){
-        if(this._utils.disks){
-            this._utils.disks.destroy();
-            delete this._utils.disks;
-        }
-    }
-
-    _initGpuUtility(){
-        switch(this._settings.get_string('gpu-utility')){
-            case 'nvidia-settings':
-                this._utils.gpu = new NvidiaUtil.NvidiaUtil();
-                break;
-            case 'aticonfig':
-                this._utils.gpu = new AticonfigUtil.AticonfigUtil();
-                break;
-            case 'bumblebee-nvidia-smi':
-                this._utils.gpu = new BumblebeeNvidiaUtil.BumblebeeNvidiaUtil();
-                break;
-        }
-    }
-
-    _destroyGpuUtility(){
-        if(this._utils.gpu){
-            this._utils.gpu.destroy();
-            delete this._utils.gpu;
-        }
-    }
-
-    _gpuUtilityChanged(){
-        this._destroyGpuUtility();
-        this._initGpuUtility();
+    _freeipmiUtilityChanged() {
+        this._destroyFreeipmiUtility();
+        this._initFreeipmiUtility();
         this._querySensors();
-    }
-
-    _initIpmiUtility(){
-        switch(this._settings.get_string('ipmi-utility')){
-            case 'freeipmi':
-                this._utils.ipmi = new FreeipmiUtil.FreeipmiUtil();
-                break;
-        }
-    }
-
-    _destroyIpmiUtility(){
-        if(this._utils.ipmi){
-            this._utils.ipmi.destroy();
-            delete this._utils.ipmi;
-        }
-    }
-
-    _ipmiUtilityChanged(){
-        this._destroyIpmiUtility();
-        this._initIpmiUtility();
-        this._querySensors();
+        this._updateUI(true);
     }
 
     _initLiquidctlUtility() {
-        if (this._settings.get_boolean('show-liquidctl'))
-            this._utils.liquidctl = new liquidctlUtil.LiquidctlUtil();
+        if (this._settings.get_boolean('use-generic-liquidctl'))
+            this._utils.liquidctl = new LiquidctlUtil();
     }
 
     _destroyLiquidctlUtility() {
@@ -292,6 +286,142 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
         this._destroyLiquidctlUtility();
         this._initLiquidctlUtility();
         this._querySensors();
+        this._updateUI(true);
+    }
+
+    _initNvidiaUtility() {
+        if (this._settings.get_boolean('use-gpu-nvidia'))
+            this._utils.nvidia = new NvidiaUtil();
+    }
+
+    _destroyNvidiaUtility() {
+        if (this._utils.nvidia) {
+            this._utils.nvidia.destroy();
+            delete this._utils.nvidia;
+        }
+    }
+
+    _nvidiaUtilityChanged() {
+        this._destroyNvidiaUtility();
+        this._initNvidiaUtility();
+        this._querySensors();
+        this._updateUI(true);
+    }
+
+    _initBumblebeeNvidiaUtility() {
+        if (this._settings.get_boolean('use-gpu-bumblebeenvidia'))
+            this._utils.nvidiabumblebee = new BumblebeeNvidiaUtil();
+    }
+
+    _destroyBumblebeeNvidiaUtility() {
+        if (this._utils.nvidiabumblebee) {
+            this._utils.nvidiabumblebee.destroy();
+            delete this._utils.nvidiabumblebee;
+        }
+    }
+
+    _nvidiabumblebeeUtilityChanged() {
+        this._destroyBumblebeeNvidiaUtility();
+        this._initBumblebeeNvidiaUtility();
+        this._querySensors();
+        this._updateUI(true);
+    }
+
+    _initAticonfigUtility() {
+        if (this._settings.get_boolean('use-gpu-aticonfig'))
+            this._utils.aticonfig = new AticonfigUtil();
+    }
+
+    _destroyAticonfigUtility() {
+        if (this._utils.aticonfig) {
+            this._utils.aticonfig.destroy();
+            delete this._utils.aticonfig;
+        }
+    }
+
+    _aticonfigUtilityChanged() {
+        this._destroyAticonfigUtility();
+        this._initAticonfigUtility();
+        this._querySensors();
+        this._updateUI(true);
+    }
+
+    _initUdisks2Utility() {
+        if (this._settings.get_boolean('use-drive-udisks2'))
+            this._utils.udisks2 = new Udisks2Util(() => {
+                 // this._updateDisplay(); we cannot change actor in background thread #74
+            });
+    }
+
+    _destroyUdisks2Utility() {
+        if (this._utils.udisks2) {
+            this._utils.udisks2.destroy();
+            delete this._utils.udisks2;
+        }
+    }
+
+    _udisks2UtilityChanged() {
+        this._destroyUdisks2Utility();
+        this._initUdisks2Utility();
+        this._querySensors();
+        this._updateUI(true);
+    }
+
+    _initHddtempUtility() {
+        if (this._settings.get_boolean('use-drive-hddtemp'))
+            this._utils.hddtemp = new HddtempUtil();
+    }
+
+    _destroyHddtempUtility() {
+        if (this._utils.hddtemp) {
+            this._utils.hddtemp.destroy();
+            delete this._utils.hddtemp;
+        }
+    }
+
+    _hddtempUtilityChanged() {
+        this._destroyHddtempUtility();
+        this._initHddtempUtility();
+        this._querySensors();
+        this._updateUI(true);
+    }
+
+    _initSmartctlUtility() {
+        if (this._settings.get_boolean('use-drive-smartctl'))
+            this._utils.smartctl = new SmartctlUtil();
+    }
+
+    _destroySmartctlUtility() {
+        if (this._utils.smartctl) {
+            this._utils.smartctl.destroy();
+            delete this._utils.smartctl;
+        }
+    }
+
+    _smartctlUtilityChanged() {
+        this._destroySmartctlUtility();
+        this._initSmartctlUtility();
+        this._querySensors();
+        this._updateUI(true);
+    }
+
+    _initNvmecliUtility() {
+        if (this._settings.get_boolean('use-drive-nvmecli'))
+            this._utils.nvmecli = new NvmecliUtil();
+    }
+
+    _destroyNvmecliUtility() {
+        if (this._utils.nvmecli) {
+            this._utils.nvmecli.destroy();
+            delete this._utils.nvmecli;
+        }
+    }
+
+    _nvmecliUtilityChanged() {
+        this._destroyNvmecliUtility();
+        this._initNvmecliUtility();
+        this._querySensors();
+        this._updateUI(true);
     }
 
     _updateTimeChanged(){
@@ -312,10 +442,19 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
     }
 
     _onButtonDestroy(){
-        this._destroyDriveUtility();
-        this._destroyGpuUtility();
-        this._destroyIpmiUtility();
+        this._destroySensorsUtility();
+        this._destroyFreeipmiUtility();
         this._destroyLiquidctlUtility();
+
+        this._destroyNvidiaUtility();
+        this._destroyBumblebeeNvidiaUtility();
+        this._destroyAticonfigUtility();
+
+        this._destroyUdisks2Utility();
+        this._destroyHddtempUtility();
+        this._destroySmartctlUtility();
+        this._destroyNvmecliUtility();
+
         Mainloop.source_remove(this._timeoutId);
         Mainloop.source_remove(this._updateUITimeoutId);
 
@@ -342,6 +481,7 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
                 needUpdate = true;
             }
         }
+
         if(needUpdate) {
             this._updateDisplay(); // #74
             this.debug('update display');
@@ -350,60 +490,95 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
 
     _fixNames(sensors){
         let names = [];
+
         for (let s of sensors){
             if(s.type == 'separator' ||
                s.type == 'temperature-group' ||
                s.type == 'temperature-average' ||
                s.type == 'temperature-maximum')
                 continue;
+
             let name = s.label;
             let i = 1;
+
             while(names.indexOf(name) >= 0){
                 name = s.label + '-' + i++;
             }
+
             if(name != s.label){
                 s.displayName = s.label;
                 s.label = name;
             }
+
             names.push(name);
         }
     }
 
     _updateDisplay(){
-        let sensorsTempInfo = this._utils.sensors.temp;
-
-        let gpuTempInfo = this._utils.sensors.gpu;
-        if (this._utils.gpu && this._utils.gpu.available)
-            gpuTempInfo = gpuTempInfo.concat(this._utils.gpu.temp);
-
+        let sensorsTempInfo = [];
+        let gpuTempInfo = []
+        let driveTempInfo = [];
         let fanInfo = [];
-        if (this._settings.get_boolean('show-fan-rpm'))
-            fanInfo = this._utils.sensors.rpm;
-
         let voltageInfo = [];
-        if (this._settings.get_boolean('show-voltage'))
-            voltageInfo = this._utils.sensors.volt;
 
-        let driveTempInfo = this._utils.sensors.disks;
-        if(this._utils.disks && this._utils.disks.available) {
-            driveTempInfo = driveTempInfo.concat(this._utils.disks.temp);
+        if (this._utils.sensors && this._utils.sensors.available) {
+            if (this._settings.get_boolean('show-temperature')) {
+                sensorsTempInfo = sensorsTempInfo.concat(this._utils.sensors.temp);
+                gpuTempInfo = gpuTempInfo.concat(this._utils.sensors.gpu);
+                driveTempInfo = driveTempInfo.concat(this._utils.sensors.disks);
+            }
+
+            if (this._settings.get_boolean('show-rotationrate'))
+                fanInfo = fanInfo.concat(this._utils.sensors.rpm);
+            if (this._settings.get_boolean('show-voltage'))
+                voltageInfo = voltageInfo.concat(this._utils.sensors.volt);
         }
 
-        if (this._utils.ipmi && this._utils.ipmi.available) {
-            sensorsTempInfo = sensorsTempInfo.concat(this._utils.ipmi.temp);
-            if (this._settings.get_boolean('show-fan-rpm'))
-                fanInfo = fanInfo.concat(this._utils.ipmi.rpm);
+        if (this._utils.freeipmi && this._utils.freeipmi.available) {
+            if (this._settings.get_boolean('show-temperature'))
+                sensorsTempInfo = sensorsTempInfo.concat(this._utils.freeipmi.temp);
+            if (this._settings.get_boolean('show-rotationrate'))
+                fanInfo = fanInfo.concat(this._utils.freeipmi.rpm);
             if (this._settings.get_boolean('show-voltage'))
-                voltageInfo = voltageInfo.concat(this._utils.ipmi.volt);
+                voltageInfo = voltageInfo.concat(this._utils.freeipmi.volt);
         }
 
         if (this._utils.liquidctl && this._utils.liquidctl.available) {
-            sensorsTempInfo = sensorsTempInfo.concat(this._utils.liquidctl.temp);
-            if (this._settings.get_boolean('show-fan-rpm'))
+            if (this._settings.get_boolean('show-temperature'))
+                sensorsTempInfo = sensorsTempInfo.concat(this._utils.liquidctl.temp);
+            if (this._settings.get_boolean('show-rotationrate'))
                 fanInfo = fanInfo.concat(this._utils.liquidctl.rpm);
             if (this._settings.get_boolean('show-voltage'))
                 voltageInfo = voltageInfo.concat(this._utils.liquidctl.volt);
         }
+
+        if (this._utils.nvidia && this._utils.nvidia.available)
+            if (this._settings.get_boolean('show-temperature'))
+                gpuTempInfo = gpuTempInfo.concat(this._utils.nvidia.temp);
+
+        if (this._utils.bumblebeenvidia && this._utils.bumblebeenvidia.available)
+            if (this._settings.get_boolean('show-temperature'))
+                gpuTempInfo = gpuTempInfo.concat(this._utils.bumblebeenvidia.temp);
+
+        if (this._utils.aticonfig && this._utils.aticonfig.available)
+            if (this._settings.get_boolean('show-temperature'))
+                gpuTempInfo = gpuTempInfo.concat(this._utils.aticonfig.temp);
+
+        if (this._utils.udisks2 && this._utils.udisks2.available)
+            if (this._settings.get_boolean('show-temperature'))
+                driveTempInfo = driveTempInfo.concat(this._utils.udisks2.temp);
+
+        if (this._utils.hddtemp && this._utils.hddtemp.available)
+            if (this._settings.get_boolean('show-temperature'))
+                driveTempInfo = driveTempInfo.concat(this._utils.hddtemp.temp);
+
+        if (this._utils.smartctl && this._utils.smartctl.available)
+            if (this._settings.get_boolean('show-temperature'))
+                driveTempInfo = driveTempInfo.concat(this._utils.smartctl.temp);
+
+        if (this._utils.nvmecli && this._utils.nvmecli.available)
+            if (this._settings.get_boolean('show-temperature'))
+                driveTempInfo = driveTempInfo.concat(this._utils.nvmecli.temp);
 
         sensorsTempInfo.sort(function(a,b) { return a.label.localeCompare(b.label) });
         driveTempInfo.sort(function(a,b) { return a.label.localeCompare(b.label) });
@@ -412,78 +587,127 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
 
         let tempInfo = gpuTempInfo.concat(sensorsTempInfo).concat(driveTempInfo);
 
-        if (tempInfo.length > 0){
-            let total = 0;
-            let sum = 0;
-            let max = 0;
-            for (let i of tempInfo){
-                if(i.temp !== null && i.temp >= 0){
+        if (tempInfo.length == 0
+            && fanInfo.length == 0
+            && voltageInfo.length == 0) {
+            this._sensorMenuItems = {};
+            this.menu.removeAll();
+
+            let item = new PopupMenu.PopupMenuItem(
+                this._utils.sensors && this._utils.sensors.available
+                    ? _("Please run sensors-detect as root.")
+                    : _("Please install lm_sensors.\nIf this doesn\'t help, click here to report with your sensors output!")
+            );
+
+            item.connect('activate',function() {
+                Util.spawn(["xdg-open", "https://github.com/UshakovVasilii/gnome-shell-extension-freon/wiki/Dependency"]);
+            });
+
+            this.menu.addMenuItem(item);
+            this._appendStaticMenuItems();
+
+            for (let k in this._hotLabels)
+                this._hotLabels[k].set_text('\u26a0');  // ⚠, warning
+        } else {
+            let tempMean = 0;
+            let tempMax = 0;
+
+            for (let i of tempInfo) {
+                let sum = 0;
+                let total = 0;
+
+                if (i.temp !== null && i.temp >= 0) {
                     total++;
                     sum += i.temp;
-                    if (i.temp > max)
-                        max = i.temp;
+
+                    if (i.temp > tempMax)
+                        tempMax = i.temp;
                 }
+
+                if (total != 0)
+                    tempMean = sum / total;
             }
 
             let sensors = [];
 
-            for (let i of gpuTempInfo){
+            for (let i of gpuTempInfo) {
                 sensors.push({
-                    type: 'gpu-temperature',
+                    icon: 'gpu-temperature',
+                    type: 'temperature',
                     label: i.label,
                     value: this._formatTemp(i.temp),
                     displayName: i.displayName});
             }
-            for (let i of sensorsTempInfo){
-                sensors.push({type:'temperature', label: i.label, value:this._formatTemp(i.temp)});
-            }
-            for (let i of driveTempInfo){
-                sensors.push({type:'drive-temperature', label: i.label, value:this._formatTemp(i.temp)});
+
+            for (let i of sensorsTempInfo) {
+                sensors.push({
+                    icon: 'temperature',
+                    type: 'temperature',
+                    label: i.label,
+                    value: this._formatTemp(i.temp)});
             }
 
-            if (tempInfo.length > 0){
+            for (let i of driveTempInfo) {
+                sensors.push({
+                    icon: 'drive-temperature',
+                    type: 'temperature',
+                    label: i.label,
+                    value: this._formatTemp(i.temp)});
+            }
+
+            if (tempInfo.length > 0) {
                 sensors.push({type : 'separator'});
 
                 // Add average and maximum entries
-                sensors.push({type: 'temperature-average',
-                              key: '__average__',
-                              label: _("Average"),
-                              value: this._formatTemp(sum/total)});
-                sensors.push({type: 'temperature-maximum',
-                              key: '__max__',
-                              label: _("Maximum"),
-                              value: this._formatTemp(max)});
+                sensors.push({
+                    icon: 'temperature-average',
+                    type: 'temperature-average',
+                    key: '__average__',
+                    label: _("Average"),
+                    value: this._formatTemp(tempMean)});
 
-                if(fanInfo.length > 0 || voltageInfo.length > 0)
+                sensors.push({
+                    icon: 'temperature-maximum',
+                    type: 'temperature-maximum',
+                    key: '__max__',
+                    label: _("Maximum"),
+                    value: this._formatTemp(tempMax)});
+
+                if (fanInfo.length > 0 || voltageInfo.length > 0)
                     sensors.push({type : 'separator'});
             }
 
-            if(sensorsTempInfo.length > 0 && this._settings.get_boolean('group-temperature')){
-                sum = 0;
-                for (let i of sensorsTempInfo){
-                    sum += i.temp;
-                }
+            if (tempInfo.length > 0 && this._settings.get_boolean('group-temperature')) {
                 sensors.push({
-                    type:'temperature-group',
-                    label:'temperature-group',
-                    value: this._formatTemp(sum / sensorsTempInfo.length)});
+                    icon: 'temperature-group',
+                    type: 'temperature-group',
+                    label: 'temperature-group',
+                    value: this._formatTemp(tempMean)});
             }
 
             for (let fan of fanInfo){
+                const unit = this._settings.get_boolean('show-rotationrate-unit') ? _('rpm'): '';
+
                 sensors.push({
-                    type:'fan',
-                    label:fan.label,
-                    value:_("%drpm").format(fan.rpm)});
+                    icon: 'fan',
+                    type: 'fan',
+                    label: fan.label,
+                    value: _("%d%s").format(fan.rpm, unit)});
             }
+
             if (fanInfo.length > 0 && voltageInfo.length > 0){
                 sensors.push({type : 'separator'});
             }
+
             for (let voltage of voltageInfo){
+                const unit = this._settings.get_boolean('show-voltage-unit') ? _('V'): '';
+
                 sensors.push({
-                    type : 'voltage',
-                    label:voltage.label,
-                    value:_("%s%.2fV").format(((voltage.volt >= 0) ? '+' : ''),
-                    voltage.volt)});
+                    icon: 'voltage',
+                    type: 'voltage',
+                    label: voltage.label,
+                    value: _("%s%.2f%s").format(((voltage.volt >= 0) ? '+' : ''),
+                    voltage.volt, unit)});
             }
 
             this._fixNames(sensors);
@@ -525,20 +749,6 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
                 this.menu.removeAll();
                 this._appendMenuItems(sensors);
             }
-        } else {
-            this._sensorMenuItems = {};
-            this.menu.removeAll();
-
-            let item = new PopupMenu.PopupMenuItem(
-                this._utils.sensors.available
-                    ? _("Please run sensors-detect as root.")
-                    : _("Please install lm_sensors.\nIf this doesn\'t help, click here to report with your sensors output!")
-            );
-            item.connect('activate',function() {
-                Util.spawn(["xdg-open", "https://github.com/UshakovVasilii/gnome-shell-extension-freon/wiki/Dependency"]);
-            });
-            this.menu.addMenuItem(item);
-            this._appendStaticMenuItems();
         }
     }
 
@@ -549,8 +759,9 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
         let wiki = new PopupMenu.PopupBaseMenuItem();
         wiki.actor.add_child(new St.Label({ text: _("Go to the Freon wiki"), x_align: Clutter.ActorAlign.START, x_expand: true }));
         wiki.connect('activate', function () {
-                            Util.spawn(["xdg-open", "https://github.com/UshakovVasilii/gnome-shell-extension-freon/wiki"]);
+            Util.spawn(["xdg-open", "https://github.com/UshakovVasilii/gnome-shell-extension-freon/wiki"]);
         });
+
         this.menu.addMenuItem(wiki);
 
         let settings = new PopupMenu.PopupBaseMenuItem();
@@ -558,6 +769,7 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
         settings.connect('activate', function () {
             Util.spawn(["gnome-extensions", "prefs", Me.metadata.uuid]);
         });
+
         this.menu.addMenuItem(settings);
     }
 
@@ -565,23 +777,38 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
         this._lastSensorsCount = sensors.length;
         this._sensorMenuItems = {};
         let needGroupTemperature = this._settings.get_boolean('group-temperature');
+        let needGroupRotationRate = this._settings.get_boolean('group-rotationrate');
         let needGroupVoltage = this._settings.get_boolean('group-voltage');
 
-        if(needGroupVoltage){
+        if (needGroupRotationRate) {
             let i = 0;
+
             for (let s of sensors)
-                if(s.type == 'voltage')
+                if (s.type == 'fan')
                     i++;
-            if(i < 2)
+
+            if (i < 2)
+                needGroupRotationRate = false;
+        }
+
+        if (needGroupVoltage) {
+            let i = 0;
+
+            for (let s of sensors)
+                if (s.type == 'voltage')
+                    i++;
+
+            if (i < 2)
                 needGroupVoltage = false;
         }
 
         let temperatureGroup = null;
+        let rotationrateGroup = null;
         let voltageGroup = null;
 
         for (let s of sensors){
-            if(s.type == 'separator'){
-                 this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+            if(s.type == 'separator') {
+                this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
             } else if (s.type == 'temperature-group') {
                 if(temperatureGroup) {
                     temperatureGroup.status.text = s.value;
@@ -589,46 +816,54 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
                 }
             } else {
                 let key = s.key || s.label;
-                let item = new FreonItem.FreonItem(this._sensorIcons[s.type], key, s.label, s.value, s.displayName || undefined);
+                let item = new FreonItem(this._sensorIcons[s.icon], key, s.label, s.value, s.displayName || undefined);
+
                 item.connect('activate', (self) => {
                     let l = this._hotLabels[self.key];
                     let hotSensors = this._settings.get_strv('hot-sensors');
-                    if(l){
+
+                    if (l) {
                         hotSensors.splice(hotSensors.indexOf(self.key), 1);
                         delete this._hotLabels[self.key];
                         l.destroy(); // destroy is called after dict cleanup to prevert set_label on not exist actor
                         let i = this._hotIcons[self.key];
-                        if(i){
+
+                        if (i) {
                             i.destroy();
                             delete this._hotIcons[self.key];
                         }
+
                         self.main = false;
                     } else {
                         hotSensors.push(self.key);
-                        if(Object.keys(this._hotLabels).length == 0){
+
+                        if (Object.keys(this._hotLabels).length == 0) {
                             this._initialIcon.destroy();
                             this._initialIcon = null;
                         }
+
                         let showIcon = this._settings.get_boolean('show-icon-on-panel');
                         this._createHotItem(self.key, showIcon, self.gicon);
                         self.main = true;
                     }
 
-                    for(let i = hotSensors.length -1; i >= 0 ; i--){
+                    for (let i = hotSensors.length -1; i >= 0 ; i--) {
                         let k = hotSensors[i];
-                        if(!this._sensorMenuItems[k]){
+
+                        if (!this._sensorMenuItems[k]) {
                             hotSensors.splice(i, 1);
                             let ll = this._hotLabels[k]
                             delete this._hotLabels[k];
                             ll.destroy(); // destroy is called after dict cleanup to prevert set_label on not exist actor
-                            if(this._hotIcons[k]){
+
+                            if (this._hotIcons[k]) {
                                 this._hotIcons[k].destroy();
                                 delete this._hotIcons[k];
                             }
                         }
                     }
 
-                    if(Object.keys(this._hotLabels).length == 0)
+                    if (Object.keys(this._hotLabels).length == 0)
                         this._createInitialIcon();
 
                     this._settings.set_strv('hot-sensors', hotSensors.filter(
@@ -636,33 +871,47 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
                             return hotSensors.indexOf(item) == pos;
                         }));
                 });
+
                 if (this._hotLabels[key]) {
                     item.main = true;
                     if(this._hotIcons[key])
                         this._hotIcons[key].gicon = item.gicon;
                 }
+
                 this._sensorMenuItems[key] = item;
 
-                if(needGroupTemperature && s.type == 'temperature') {
-                    if(!temperatureGroup) {
-                        temperatureGroup = new PopupMenu.PopupSubMenuMenuItem(_('Temperature Sensors'), true);
+                if (needGroupTemperature && s.type == 'temperature') {
+                    if (!temperatureGroup) {
+                        temperatureGroup = new PopupMenu.PopupSubMenuMenuItem(_('Temperature'), true);
                         temperatureGroup.icon.gicon = this._sensorIcons['temperature'];
-                        if(!temperatureGroup.status) { // gnome 3.18 and hight
+
+                        if (!temperatureGroup.status) { // gnome 3.18 and hight
                             temperatureGroup.status = new St.Label({
                                      style_class: 'popup-status-menu-item',
                                      y_expand: true,
                                      y_align: Clutter.ActorAlign.CENTER });
                             temperatureGroup.actor.insert_child_at_index(temperatureGroup.status, 4);
                         }
+
                         this.menu.addMenuItem(temperatureGroup);
                     }
+
                     temperatureGroup.menu.addMenuItem(item);
-                } else if(needGroupVoltage && s.type == 'voltage') {
-                    if(!voltageGroup) {
+                } else if (needGroupRotationRate && s.type == 'fan') {
+                    if (!rotationrateGroup) {
+                        rotationrateGroup = new PopupMenu.PopupSubMenuMenuItem(_('Rotation Rate'), true);
+                        rotationrateGroup.icon.gicon = this._sensorIcons['fan'];
+                        this.menu.addMenuItem(rotationrateGroup);
+                    }
+
+                    rotationrateGroup.menu.addMenuItem(item);
+                } else if (needGroupVoltage && s.type == 'voltage') {
+                    if (!voltageGroup) {
                         voltageGroup = new PopupMenu.PopupSubMenuMenuItem(_('Voltage'), true);
                         voltageGroup.icon.gicon = this._sensorIcons['voltage'];
                         this.menu.addMenuItem(voltageGroup);
                     }
+
                     voltageGroup.menu.addMenuItem(item);
                 } else {
                     this.menu.addMenuItem(item);
@@ -689,7 +938,7 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
         }
         format += '%s';
 
-        if(this._settings.get_boolean('show-degrees-on-panel')){
+        if(this._settings.get_boolean('show-temperature-unit')){
             return format.format(value, (this._settings.get_string('unit')=='fahrenheit') ? "\u00b0F" : "\u00b0C" );
         } else {
             return format.format(value, "");

--- a/freon@UshakovVasilii_Github.yahoo.com/freeipmiUtil.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/freeipmiUtil.js
@@ -14,7 +14,7 @@ var FreeipmiUtil = class extends CommandLineUtil.CommandLineUtil {
         if (this._argv) {
             const ExtensionUtils = imports.misc.extensionUtils;
             const Me = ExtensionUtils.getCurrentExtension();
-            if (ExtensionUtils.getSettings().get_string('method-ipmi-utility') === 'sudo')
+            if (ExtensionUtils.getSettings().get_string('exec-method-freeipmi') === 'sudo')
             {
                 const sudo_path = GLib.find_program_in_path('sudo');
                 // --non-interactive: do not ask for password, return if no permission.

--- a/freon@UshakovVasilii_Github.yahoo.com/nvmecliUtil.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/nvmecliUtil.js
@@ -7,7 +7,7 @@ function getNvmeData (argv){
     return JSON.parse(GLib.spawn_command_line_sync(`${nvme} ${argv} -o json`)[1].toString())
 }
 
-var nvmecliUtil  = class {
+var NvmecliUtil  = class {
     constructor(callback) {
         this._nvmeDevices = [];
         try {

--- a/freon@UshakovVasilii_Github.yahoo.com/prefs.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/prefs.js
@@ -26,99 +26,173 @@ var FreonPrefsWidget = new GObject.registerClass(class Freon_FreonPrefsWidget ex
         this._settings = ExtensionUtils.getSettings();
 
         let i = 0;
+        let j = 0;
 
-        this.attach(new Gtk.Label({ label: _('Poll Sensors Every (sec)'), halign : Gtk.Align.END}), 0, i, 1, 1);
-        let updateTime = Gtk.SpinButton.new_with_range (1, 60, 1);
-        this.attach(updateTime, 1, i++, 1, 1);
-        this._settings.bind('update-time', updateTime, 'value', Gio.SettingsBindFlags.DEFAULT);
-
-        this._addSwitch({key : 'show-decimal-value', y : i, x : 0,
-            label : _('Show Decimal Value'),
-            help : _("Show one digit after decimal")});
-
-        this._addComboBox({
-            items : {centigrade : "\u00b0C", fahrenheit : "\u00b0F"},
-            key: 'unit', y : i++, x : 3,
-            label: _('Temperature Unit')
+        this._addLabel({
+            label: _('Display Options'),
+            y : i++, x : j
         });
 
+        this._addLabel({
+            label: _('Poll Sensors Every (sec)'),
+            y : i, x : j
+        });
+
+        let updateTime = Gtk.SpinButton.new_with_range (1, 60, 1);
+        this.attach(updateTime, j + 1, i++, 1, 1);
+        this._settings.bind('update-time', updateTime, 'value', Gio.SettingsBindFlags.DEFAULT);
+
         this._addComboBox({
+            label: _('Position on Panel'),
             items : {left : _('Left'), center : _('Center'), right : _('Right')},
-            key: 'position-in-panel', y : i, x : 0,
-            label: _('Position in Panel')
+            key: 'position-in-panel', y : i++, x : j
+        });
+
+        this._addLabel({
+            label: _('Index on Panel'),
+            y : i, x : j
         });
 
         let panelBoxIndex = Gtk.SpinButton.new_with_range (-1, 20, 1);
-        this.attach(panelBoxIndex, 2, i, 1, 1);
+        this.attach(panelBoxIndex, j + 1, i++, 1, 1);
         this._settings.bind('panel-box-index', panelBoxIndex, 'value', Gio.SettingsBindFlags.DEFAULT);
 
-        this._addSwitch({key : 'show-degrees-on-panel', y : i++, x : 3,
-            label : _('Show \u00b0C/\u00b0F on Panel')});
-
-        this._addSwitch({key : 'show-icon-on-panel', y : i++, x : 3,
+        this._addSwitch({key : 'show-icon-on-panel', y : i++, x : j,
             label : _('Show Icon on Panel')});
 
-        this._addSwitch({key : 'show-fan-rpm', y : i, x : 0,
-            label : _('Show Fan Speed')});
-
-        this._addSwitch({key : 'show-voltage', y : i++, x : 3,
-            label : _('Show Power Supply Voltage')});
-
-        this._addSwitch({key : 'group-temperature', y : i, x : 0,
-            label : _('Group Temperature Items'),
-            help : _("Works if you have more than three temperature sensors")});
-
-        this._addSwitch({key : 'group-voltage', y : i++, x : 3,
-            label : _('Group Voltage Items'),
-            help : _("Works if you have more than three voltage sensors")});
-
         this._addComboBox({
-            items : {none : _('None'), hddtemp : 'Hddtemp', udisks2 : 'UDisks2', smartctl : 'smartctl', nvmecli : 'nvme-cli'},
-            key: 'drive-utility', y : i, x : 0,
-            label: _('HDD/SSD Temperature Utility')
+            label: 'Temperature Unit',
+            items : {centigrade : _("\u00b0C"), fahrenheit : _("\u00b0F")},
+            key: 'unit', y : i++, x : j
         });
 
-        this._addComboBox({
-            items : {
-                'none' : _('None'),
-                'nvidia-settings' : _('NVIDIA'),
-                'aticonfig' : _('Catalyst'),
-                'bumblebee-nvidia-smi': _('Bumblebee + NVIDIA') },
-            key: 'gpu-utility', y : i++, x : 3,
-            label: _('Video Card Temperature Utility')
+        this._addSwitch({key : 'show-temperature-unit', y : i++, x : j,
+            label : _('Show Temperature Unit')});
+
+        this._addSwitch({key : 'show-rotationrate-unit', y : i++, x : j,
+            label : _('Show Rotation Rate Unit')});
+
+        this._addSwitch({key : 'show-voltage-unit', y : i++, x : j,
+            label : _('Show Voltage Unit')});
+
+        this._addSwitch({key : 'show-decimal-value', y : i++, x : j,
+            label : _('Show Decimal Values'),
+            help : _("Show additionnal digits after decimal point")});
+
+        i = 0;
+        j = 2;
+
+        this._addLabel({
+            label: _('Generic Sensor Providers'),
+            y : i++, x : j
         });
 
-        this._addComboBox({
-            items : {
-                'none' : _('None'),
-                'freeipmi' : _('FreeIPMI') },
-            key: 'ipmi-utility', y : i, x : 0,
-            label: _('IPMI Sensors Utility')
-        });
+        this._addSwitch({key : 'use-generic-lmsensors', y : i++, x : j,
+            label : 'lm-sensors',
+            help : _('Read sensors from lm-sensors')});
+
+        this._addSwitch({key : 'use-generic-freeipmi', y : i, x : j,
+            label : 'FreeIPMI',
+            help : _('Read sensors using ipmi-sensors from FreeIPMI')});
 
         this._addComboBox({
             items : {
                 'direct' : 'Direct',
                 'sudo' : 'sudo' },
-            key: 'method-ipmi-utility', y : i, x : 1,
+            key: 'exec-method-freeipmi', y : i++, x : j + 1,
             label: ''
         });
 
-        this._addSwitch({key : 'show-liquidctl', y : i++, x : 3,
-            label : _('Show liquidctl Sensors'),
-            help : _('Show data from liquidctl v1.7.0 or later')});
+        this._addSwitch({key : 'use-generic-liquidctl', y : i++, x : j,
+            label : 'liquidctl',
+            help : _('Read sensors from liquidctl (requires v1.7.0 or later)')});
 
+        this._addLabel({
+            label: _('GPU Sensor Providers'),
+            y : i++, x : j
+        });
+
+        this._addSwitch({key : 'use-gpu-nvidia', y : i++, x : j,
+            label : 'Nvidia'});
+
+        this._addSwitch({key : 'use-gpu-bumblebeenvidia', y : i++, x : j,
+            label : 'Bumblebee + Nvidia'});
+
+        this._addSwitch({key : 'use-gpu-aticonfig', y : i++, x : j,
+            label : 'Catalyst'});
+
+        this._addLabel({
+            label: _('Drive Sensor Providers'),
+            y : i++, x : j
+        });
+
+        this._addSwitch({key : 'use-drive-udisks2', y : i++, x : j,
+            label : 'Udisks2'});
+
+        this._addSwitch({key : 'use-drive-hddtemp', y : i++, x : j,
+            label : 'Hddtemp'});
+
+        this._addSwitch({key : 'use-drive-smartctl', y : i++, x : j,
+            label : 'smartctl',
+            help : _('Read drive sensors from smartctl from smartmontools')});
+
+        this._addSwitch({key : 'use-drive-nvmecli', y : i++, x : j,
+            label : 'nvme-cli'});
+
+        i = 0;
+        j = 5;
+
+        this._addLabel({
+            label: _('Show Sensors'),
+            y : i++, x : j
+        });
+
+        this._addSwitch({key : 'show-temperature', y : i++, x : j,
+            label : _('Temperature')});
+
+        this._addSwitch({key : 'show-rotationrate', y : i++, x : j,
+            label : _('Rotation Rate')});
+
+        this._addSwitch({key : 'show-voltage', y : i++, x : j,
+            label : _('Voltage')});
+
+        this._addLabel({
+            label: _('Group Items'),
+            y : i++, x : j
+        });
+
+        this._addSwitch({key : 'group-temperature', y : i++, x : j,
+            label : _('Temperature'),
+            help : _("Group three or more temperature sensors")});
+
+        this._addSwitch({key : 'group-rotationrate', y : i++, x : j,
+            label : _('Rotation Rate'),
+            help : _("Group three or more rotation rate sensors")});
+
+        this._addSwitch({key : 'group-voltage', y : i++, x : j,
+            label : _('Voltage'),
+            help : _("Group three or more voltage sensors")});
+    }
+
+    _addLabel(params){
+        let lbl = new Gtk.Label({label: params.label,halign : Gtk.Align.END});
+        this.attach(lbl, params.x, params.y, 1, 1);
+
+        if(params.help){
+            lbl.set_tooltip_text(params.help);
+        }
     }
 
     _addSwitch(params){
-        let lbl = new Gtk.Label({label: params.label,halign : Gtk.Align.END});
-        this.attach(lbl, params.x, params.y, 1, 1);
+        this._addLabel(params);
+
         let sw = new Gtk.Switch({halign : Gtk.Align.END, valign : Gtk.Align.CENTER});
         this.attach(sw, params.x + 1, params.y, 1, 1);
+
         if(params.help){
-            lbl.set_tooltip_text(params.help);
             sw.set_tooltip_text(params.help);
         }
+
         this._settings.bind(params.key, sw, 'active', Gio.SettingsBindFlags.DEFAULT);
     }
 
@@ -144,7 +218,8 @@ var FreonPrefsWidget = new GObject.registerClass(class Freon_FreonPrefsWidget ex
             this._settings.set_string(params.key, model.get_value(iter, 0))
         });
 
-        this.attach(new Gtk.Label({ label: params.label, halign : Gtk.Align.END}), params.x, params.y, 1, 1);
+        this._addLabel(params);
+
         this.attach(combobox, params.x + 1, params.y, 1, 1);
     }
 });

--- a/freon@UshakovVasilii_Github.yahoo.com/schemas/org.gnome.shell.extensions.sensors.gschema.xml
+++ b/freon@UshakovVasilii_Github.yahoo.com/schemas/org.gnome.shell.extensions.sensors.gschema.xml
@@ -3,82 +3,16 @@
 
   <schema id="org.gnome.shell.extensions.freon" path="/org/gnome/shell/extensions/freon/">
 
-    <key type="i" name="update-time">
-      <default>5</default>
-      <summary>Seconds before next update</summary>
-      <description>This is the seconds after CPU temperature extension updates the data from the syetem</description>
-    </key>
-
-    <key type="s" name="unit">
-      <default>'centigrade'</default>
-      <summary>Unit</summary>
-      <description>The unit ('centigrade' or 'fahrenheit') the extension should display the temperature in</description>
-    </key>
-    
-    <key type="b" name="show-degrees-on-panel">
-      <default>true</default>
-      <summary>Show degrees celsius/fahrenheit on Panel</summary>
-      <description>Show degrees celsius/fahrenheit on Panel</description>
-    </key>
-
-    <key type="b" name="show-icon-on-panel">
-      <default>true</default>
-      <summary>Show Icon on Panel</summary>
-      <description>Show sensor icon on top panel</description>
-    </key>
-
     <key name="hot-sensors" type="as">
       <default>["__average__", "__max__"]</default>
       <summary>Sensors to show in panel</summary>
       <description>Select the sensord whose values has to be shown in the panel</description>
     </key>
 
-    <key type="b" name="show-decimal-value">
-      <default>false</default>
-      <summary>Show decimal value</summary>
-      <description>Show one digit after decimal</description>
-    </key>
-
-    <key type="b" name="show-fan-rpm">
-      <default>true</default>
-      <summary>Display Fan RPM</summary>
-      <description>Display fan rotation per minute</description>
-    </key>
-
-    <key type="b" name="show-voltage">
-      <default>true</default>
-      <summary>Display voltage</summary>
-      <description>Display voltage of various components</description>
-    </key>
-
-    <key type="s" name="drive-utility">
-      <default>'udisks2'</default>
-      <summary>Utility for detect HDD/SSD temperature</summary>
-      <description>Utility for detect HDD/SSD temperature ('none', 'hddtemp' or 'udisks2')</description>
-    </key>
-
-    <key type="s" name="gpu-utility">
-      <default>'none'</default>
-      <summary>Utility for detect video card temperature</summary>
-      <description>Utility for detect video card temperature ('none', 'nvidia-settings' or 'aticonfig')</description>
-    </key>
-
-    <key type="s" name="ipmi-utility">
-      <default>'none'</default>
-      <summary>Utility for reading IPMI sensors</summary>
-      <description>Utility reading IPMI sensors ('none', 'freeipmi')</description>
-    </key>
-
-    <key type="s" name="method-ipmi-utility">
-      <default>'direct'</default>
-      <summary>Method to run IPMI utility</summary>
-      <description>Method to run IPMI utility</description>
-    </key>
-
-    <key type="b" name="show-liquidctl">
-      <default>false</default>
-      <summary>Show liquidctl sensors</summary>
-      <description>Show data from liquidctl v1.7.0 or later</description>
+    <key type="i" name="update-time">
+      <default>5</default>
+      <summary>Seconds before next update</summary>
+      <description>This is the seconds after CPU temperature extension updates the data from the syetem</description>
     </key>
 
     <key type="s" name="position-in-panel">
@@ -93,16 +27,142 @@
       <description>Index within the selected panel box (0: first, 1: second, ..., -1: last)</description>
     </key>
 
+    <key type="b" name="show-icon-on-panel">
+      <default>true</default>
+      <summary>Show Icon on Panel</summary>
+      <description>Show sensor icon on top panel</description>
+    </key>
+
+    <key type="b" name="show-temperature">
+      <default>true</default>
+      <summary>Display Temperature</summary>
+      <description>Display temperature</description>
+    </key>
+
+    <key type="s" name="unit">
+      <default>'centigrade'</default>
+      <summary>Unit</summary>
+      <description>The unit ('centigrade' or 'fahrenheit') the extension should display the temperature in</description>
+    </key>
+
+    <key type="b" name="show-temperature-unit">
+      <default>true</default>
+      <summary>Show degrees celsius/fahrenheit on Panel</summary>
+      <description>Show degrees celsius/fahrenheit on Panel</description>
+    </key>
+
+    <key type="b" name="show-rotationrate-unit">
+      <default>true</default>
+      <summary>Show RPM on Panel</summary>
+      <description>Show RPM on Panel</description>
+    </key>
+
+    <key type="b" name="show-voltage-unit">
+      <default>true</default>
+      <summary>Show volts on Panel</summary>
+      <description>Show volts on Panel</description>
+    </key>
+
+    <key type="b" name="show-decimal-value">
+      <default>false</default>
+      <summary>Show decimal value</summary>
+      <description>Show one digit after decimal</description>
+    </key>
+
+    <key type="b" name="use-generic-lmsensors">
+      <default>true</default>
+      <summary>Read sensors from lm-sensors</summary>
+      <description>Read sensors from lm-sensors</description>
+    </key>
+
+    <key type="b" name="use-generic-freeipmi">
+      <default>false</default>
+      <summary>Read sensors using ipmi-sensors from FreeIPMI</summary>
+      <description>Read sensors using ipmi-sensors from FreeIPMI</description>
+    </key>
+
+    <key type="s" name="exec-method-freeipmi">
+      <default>'direct'</default>
+      <summary>Method to run FreeIPMI utility</summary>
+      <description>Method to run FreeIPMI utility</description>
+    </key>
+
+    <key type="b" name="use-generic-liquidctl">
+      <default>false</default>
+      <summary>Read sensors from liquidctl</summary>
+      <description>Read sensors from (requires liquidctl v1.7.0 or later)</description>
+    </key>
+
+    <key type="b" name="use-gpu-nvidia">
+      <default>false</default>
+      <summary>Read GPU sensors from NVidia driver</summary>
+      <description>Read GPU sensors from NVidia driver</description>
+    </key>
+
+    <key type="b" name="use-gpu-bumblebeenvidia">
+      <default>false</default>
+      <summary>Read GPU sensors from Bumblebee + NVidia driver</summary>
+      <description>Read GPU sensors from Bumblebee + NVidia driver</description>
+    </key>
+
+    <key type="b" name="use-gpu-aticonfig">
+      <default>false</default>
+      <summary>Read GPU sensors from Catalyst driver</summary>
+      <description>Read GPU sensors from Catalyst driver</description>
+    </key>
+
+    <key type="b" name="use-drive-udisks2">
+      <default>false</default>
+      <summary>Read drive sensors from Udisks2</summary>
+      <description>Read drive sensors from Udisks2</description>
+    </key>
+
+    <key type="b" name="use-drive-hddtemp">
+      <default>false</default>
+      <summary>Read drive sensors using Hddtemp</summary>
+      <description>Read drive sensors using Hddtemp</description>
+    </key>
+
+    <key type="b" name="use-drive-smartctl">
+      <default>false</default>
+      <summary>Read drive sensors using smartctl</summary>
+      <description>Read drive sensors using smartctl from smartmontool</description>
+    </key>
+
+    <key type="b" name="use-drive-nvmecli">
+      <default>false</default>
+      <summary>Read drive sensors using nvme-cli</summary>
+      <description>Read drive sensors using nvme-cli</description>
+    </key>
+
+    <key type="b" name="show-rotationrate">
+      <default>true</default>
+      <summary>Display rotationrate</summary>
+      <description>Display rotation rate (per minute)</description>
+    </key>
+
+    <key type="b" name="show-voltage">
+      <default>true</default>
+      <summary>Display voltage</summary>
+      <description>Display voltage of various components</description>
+    </key>
+
     <key type="b" name="group-temperature">
       <default>true</default>
       <summary>Group temperature menu items</summary>
-      <description>Group more than three sensors temperature menu items</description>
+      <description>Group three or more temperature sensors</description>
+    </key>
+
+    <key type="b" name="group-rotationrate">
+      <default>true</default>
+      <summary>Group Fan speed menu items</summary>
+      <description>Group three or more fan sensors</description>
     </key>
 
     <key type="b" name="group-voltage">
       <default>true</default>
       <summary>Group voltage menu items</summary>
-      <description>Group more than three voltage menu items</description>
+      <description>Group three or more voltage sensors</description>
     </key>
 
     <key type="b" name="debug">

--- a/freon@UshakovVasilii_Github.yahoo.com/smartctlUtil.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/smartctlUtil.js
@@ -7,7 +7,7 @@ function getSmartData (argv){
     return JSON.parse(ByteArray.toString( GLib.spawn_command_line_sync(`'${smartctl}' ${argv} -j`)[1] ))
 }
 
-var smartctlUtil  = class {
+var SmartctlUtil  = class {
     constructor(callback) {
         this._smartDevices = [];
         try {


### PR DESCRIPTION
Remake of #224.

- revamp preference window with some column in an attempt to group options in some meaningful manner, adde some labels,
- make various providers selectable independently,
- add a group for fan speeds (not only temperature and voltage),
- made `V` and `rpm` unit hideable (not only temperature unit),
- fixed an issue where the message telling to install lm-sensors was displayed when no temperature was reported, even if there was fan speed and/or voltage sensors,
- group all temperatures in temperature group,
- deduplicated temperature mean compute (reuse the same compute for the mean line, and the collapsed group line),
- made lm-sensors disableable, for example someone may only want to monitor Udisks2 or IPMI,
- fixed various bugs were disabling the last source of sensors did not updated the panel,
- and some other things like that.

For now only FreeIPMI has an execution method option but some other providers like `smartctl`, `hddtemp` and `nvme-cli` may receive similar execution option in the same column in the future.

[![Freon: revamped preferences](https://dl.illwieckz.net/b/gnome-shell-extension-freon/shots/20211120-165512-001.freon-proposed-prefs.png)](https://dl.illwieckz.net/b/gnome-shell-extension-freon/shots/20211120-165512-001.freon-proposed-prefs.png)