### PR TITLE
Add 42 since it works there too

### DIFF
--- a/freon@UshakovVasilii_Github.yahoo.com/metadata.json
+++ b/freon@UshakovVasilii_Github.yahoo.com/metadata.json
@@ -1,5 +1,5 @@
 {
-  "shell-version": ["40", "41"],
+  "shell-version": ["40", "41", "42"],
   "uuid": "freon@UshakovVasilii_Github.yahoo.com",
   "name": "Freon",
   "description": "Shows CPU temperature, disk temperature, video card temperature (NVIDIA/Catalyst/Bumblebee&NVIDIA), voltage and fan RPM (forked from xtranophilist/gnome-shell-extension-sensors)",


### PR DESCRIPTION
Tested on Ubuntu Jammy Jellyfish + GNOME PPA with gnome-shell 42~alpha.

Preferences works too.

Thanks for this nice and useful extension.