### PR TITLE
Add space to RPM

### DIFF
--- a/freon@UshakovVasilii_Github.yahoo.com/extension.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/extension.js
@@ -686,7 +686,7 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
             }
 
             for (let fan of fanInfo){
-                const unit = this._settings.get_boolean('show-rotationrate-unit') ? _('rpm'): '';
+                const unit = this._settings.get_boolean('show-rotationrate-unit') ? _(' rpm'): '';
 
                 sensors.push({
                     icon: 'fan',


### PR DESCRIPTION
This is just a minor aesthetic fix to add a space between RPM and the speed to make it easier to read. 