### PR TITLE
Center Label in Menu Bar

### DIFF
--- a/freon@UshakovVasilii_Github.yahoo.com/freonItem.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/freonItem.js
@@ -11,7 +11,7 @@ var FreonItem = GObject.registerClass(class FreonItem extends PopupMenu.PopupBas
         this._key = key;
         this._gIcon = gIcon;
 
-        this._labelActor = new St.Label({text: displayName ? displayName : label, x_align: Clutter.ActorAlign.START, x_expand: true});
+        this._labelActor = new St.Label({text: displayName ? displayName : label, x_align: Clutter.ActorAlign.CENTER, x_expand: true});
         this.actor.add(new St.Icon({ style_class: 'popup-menu-icon', gicon : gIcon}));
         this.actor.add_child(this._labelActor);
         this._valueLabel = new St.Label({text: value});


### PR DESCRIPTION
I don't know if it's a feature but i find it ugly to look at this right-aligned temperature label on hovering.
For comparison:
![image](https://user-images.githubusercontent.com/70949550/195141032-50862bde-39f8-4db9-a7c8-8ccedebc28b1.png)![image2](https://user-images.githubusercontent.com/70949550/195135191-11f8aae2-3f00-4692-87d4-68193d1bd6f3.png)

This fixes the issue.