### PR TITLE
Add AMD PPT average power sensor

### DIFF
--- a/freon@UshakovVasilii_Github.yahoo.com/extension.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/extension.js
@@ -85,6 +85,7 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
         this._initNvmecliUtility();
 
         let temperatureIcon = Gio.icon_new_for_string(Me.path + '/icons/material-icons/material-temperature-symbolic.svg');
+        let voltageIcon = Gio.icon_new_for_string(Me.path + '/icons/freon-voltage-symbolic.svg');
 
         this._sensorIcons = {
             'temperature' : temperatureIcon,
@@ -92,8 +93,9 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
             'temperature-maximum' : temperatureIcon,
             'gpu-temperature' : Gio.icon_new_for_string(Me.path + '/icons/material-icons/material-gpu-temperature-symbolic.svg'),
             'drive-temperature' : Gio.icon_new_for_string('drive-harddisk-symbolic'),
-            'voltage' : Gio.icon_new_for_string(Me.path + '/icons/freon-voltage-symbolic.svg'),
-            'fan' : Gio.icon_new_for_string(Me.path + '/icons/freon-fan-symbolic.svg')
+            'voltage' : voltageIcon,
+            'fan' : Gio.icon_new_for_string(Me.path + '/icons/freon-fan-symbolic.svg'),
+            'power' : voltageIcon,
         }
 
         this._menuLayout = new St.BoxLayout();
@@ -127,6 +129,7 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
         this._addSettingChangedSignal('unit', this._querySensors.bind(this));
         this._addSettingChangedSignal('show-rotationrate-unit', this._updateUI.bind(this));
         this._addSettingChangedSignal('show-voltage-unit', this._updateUI.bind(this));
+        this._addSettingChangedSignal('show-power-unit', this._updateUI.bind(this));
 
         this._addSettingChangedSignal('show-decimal-value', this._querySensors.bind(this));
 
@@ -147,6 +150,7 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
         this._addSettingChangedSignal('show-temperature', this._rerender.bind(this));
         this._addSettingChangedSignal('show-rotationrate', this._rerender.bind(this));
         this._addSettingChangedSignal('show-voltage', this._rerender.bind(this));
+        this._addSettingChangedSignal('show-power', this._rerender.bind(this));
 
         this._addSettingChangedSignal('group-temperature', this._rerender.bind(this))
         this._addSettingChangedSignal('group-rotationrate', this._rerender.bind(this))
@@ -520,6 +524,7 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
         let driveTempInfo = [];
         let fanInfo = [];
         let voltageInfo = [];
+        let powerInfo = [];
 
         if (this._utils.sensors && this._utils.sensors.available) {
             if (this._settings.get_boolean('show-temperature')) {
@@ -532,6 +537,8 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
                 fanInfo = fanInfo.concat(this._utils.sensors.rpm);
             if (this._settings.get_boolean('show-voltage'))
                 voltageInfo = voltageInfo.concat(this._utils.sensors.volt);
+            if (this._settings.get_boolean('show-power'))
+                powerInfo = powerInfo.concat(this._utils.sensors.power);
         }
 
         if (this._utils.freeipmi && this._utils.freeipmi.available) {
@@ -584,6 +591,7 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
         driveTempInfo.sort(function(a,b) { return a.label.localeCompare(b.label) });
         fanInfo.sort(function(a,b) { return a.label.localeCompare(b.label) });
         voltageInfo.sort(function(a,b) { return a.label.localeCompare(b.label) });
+        powerInfo.sort(function(a,b) { return a.label.localeCompare(b.label) });
 
         let tempInfo = gpuTempInfo.concat(sensorsTempInfo).concat(driveTempInfo);
 
@@ -708,6 +716,17 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
                     label: voltage.label,
                     value: _("%s%.2f%s").format(((voltage.volt >= 0) ? '+' : ''),
                     voltage.volt, unit)});
+            }
+
+            for (let power of powerInfo){
+                const unit = this._settings.get_boolean('show-power-unit') ? _('W'): '';
+
+                sensors.push({
+                    icon: 'power',
+                    type: 'power',
+                    label: power.label,
+                    value: _("%s%.2f%s").format(((power.power >= 0) ? '+' : ''),
+                    power.power, unit)});
             }
 
             this._fixNames(sensors);

--- a/freon@UshakovVasilii_Github.yahoo.com/prefs.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/prefs.js
@@ -75,6 +75,9 @@ var FreonPrefsWidget = new GObject.registerClass(class Freon_FreonPrefsWidget ex
         this._addSwitch({key : 'show-voltage-unit', y : i++, x : j,
             label : _('Show Voltage Unit')});
 
+        this._addSwitch({key : 'show-power-unit', y : i++, x : j,
+            label : _('Show Power Unit')});
+
         this._addSwitch({key : 'show-decimal-value', y : i++, x : j,
             label : _('Show Decimal Values'),
             help : _("Show additionnal digits after decimal point")});
@@ -156,6 +159,9 @@ var FreonPrefsWidget = new GObject.registerClass(class Freon_FreonPrefsWidget ex
         this._addSwitch({key : 'show-voltage', y : i++, x : j,
             label : _('Voltage')});
 
+        this._addSwitch({key : 'show-power', y : i++, x : j,
+            label : _('Power')});
+
         this._addLabel({
             label: _('Group Items'),
             y : i++, x : j
@@ -172,7 +178,7 @@ var FreonPrefsWidget = new GObject.registerClass(class Freon_FreonPrefsWidget ex
         this._addSwitch({key : 'group-voltage', y : i++, x : j,
             label : _('Voltage'),
             help : _("Group three or more voltage sensors")});
-    }
+       }
 
     _addLabel(params){
         let lbl = new Gtk.Label({label: params.label,halign : Gtk.Align.END});

--- a/freon@UshakovVasilii_Github.yahoo.com/schemas/org.gnome.shell.extensions.sensors.gschema.xml
+++ b/freon@UshakovVasilii_Github.yahoo.com/schemas/org.gnome.shell.extensions.sensors.gschema.xml
@@ -63,6 +63,18 @@
       <description>Show volts on Panel</description>
     </key>
 
+    <key type="b" name="show-power">
+      <default>true</default>
+      <summary>Display Power</summary>
+      <description>Display power</description>
+    </key>
+
+    <key type="b" name="show-power-unit">
+      <default>true</default>
+      <summary>Show Watts on Panel</summary>
+      <description>Show Watts on Panel</description>
+    </key>
+
     <key type="b" name="show-decimal-value">
       <default>false</default>
       <summary>Show decimal value</summary>

--- a/freon@UshakovVasilii_Github.yahoo.com/sensorsUtil.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/sensorsUtil.js
@@ -56,6 +56,10 @@ var SensorsUtil = class extends CommandLineUtil.CommandLineUtil {
         return this._parseSensorsOutput(/^in\d+_input/, 'volt', 'generic');
     }
 
+    get power() {
+        return this._parseSensorsOutput(/^power\d+_average/, 'power', 'gpu');
+    }
+
   _parseSensorsOutput(sensorFilter, sensorType, sensorFamily) {
         if(!this._data)
             return [];
@@ -65,10 +69,12 @@ var SensorsUtil = class extends CommandLineUtil.CommandLineUtil {
         let sensors = [];
         for (var chipset in data) {
             let tempType = (sensorType === 'temp')
+            let powerType = (sensorType === 'power')
 
             let gpuFilter = /(radeon|amdgpu|nouveau)/;
             let gpuFamily = (sensorFamily === 'gpu')
-            if (!data.hasOwnProperty(chipset) || (gpuFamily != gpuFilter.test(chipset) && tempType))
+
+            if (!data.hasOwnProperty(chipset) || (gpuFamily != gpuFilter.test(chipset) && (tempType || powerType)))
                 continue;
 
             let diskFilter = /(drivetemp|nvme)/;


### PR DESCRIPTION
Included PPT average power measurement, working for AMD Ryzen 6850U on a ThinkPad T14s gen 3.

Sample output from sensorts:
```
amdgpu-pci-3300
Adapter: PCI adapter
vddgfx:      830.00 mV 
vddnb:       724.00 mV 
edge:         +67.0°C  
PPT:          17.08 W  
...
```

![image](https://user-images.githubusercontent.com/492685/200704372-891b1ffe-3a99-4f10-ade3-fc7dc57ef1f7.png)
![image](https://user-images.githubusercontent.com/492685/200704418-658eb6f6-36da-44ff-bdb6-61595d292841.png)
