### PR TITLE
Avoid blocking NVIDIA GPUs from sleeping

### DIFF
--- a/freon@UshakovVasilii_Github.yahoo.com/nvidiaUtil.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/nvidiaUtil.js
@@ -10,7 +10,83 @@ var NvidiaUtil = class extends CommandLineUtil.CommandLineUtil {
     constructor() {
         super();
         let path = GLib.find_program_in_path('nvidia-smi');
-        this._argv = path ? [path, '--query-gpu=name,temperature.gpu', '--format=csv,noheader'] : null;
+        this._argv = path ? [
+            '/bin/sh',
+            '-c',
+            `${path} --query-gpu=name,temperature.gpu --format=csv,noheader`
+        ] : null;
+    }
+
+    async execute(callback) {
+        try {
+            // Read all GPUs from /proc/driver/nvidia/gpus.
+            const directory = Gio.File.new_for_path('/proc/driver/nvidia/gpus');
+            const iter = await new Promise((resolve, reject) => {
+                directory.enumerate_children_async(
+                    'standard::*',
+                    Gio.FileQueryInfoFlags.NOFOLLOW_SYMLINKS,
+                    GLib.PRIORITY_DEFAULT,
+                    null,
+                    (file_, result) => {
+                        try {
+                            resolve(directory.enumerate_children_finish(result));
+                        } catch (e) {
+                            reject(e);
+                        }
+                    }
+                );
+            });
+            const gpus = []
+    
+            while (true) {
+                const infos = await new Promise((resolve, reject) => {
+                    iter.next_files_async(10, GLib.PRIORITY_DEFAULT, null, (iter_, res) => {
+                        try {
+                            resolve(iter.next_files_finish(res));
+                        } catch (e) {
+                            reject(e);
+                        }
+                    });
+                });
+    
+                if (infos.length === 0)
+                    break;
+    
+                for (const info of infos)
+                    gpus.push(info.get_name());
+            }
+    
+            // For each GPU...
+            let gpusToPoll = ''
+            for (const gpu of gpus) {
+                // ...read /proc/driver/nvidia/gpus/<ID>/power and check if it supports sleep.
+                const file = Gio.File.new_for_path(`/proc/driver/nvidia/gpus/${gpu}/power`);
+                const [, contents, etag] = await new Promise((resolve, reject) => {
+                    file.load_contents_async(null, (file_, result) => {
+                        try {
+                            resolve(file.load_contents_finish(result));
+                        } catch (e) {
+                            reject(e);
+                        }
+                    });
+                });
+    
+                // If the GPU is sleeping, don't poll it.
+                const decoder = new TextDecoder('utf-8');
+                const contentsString = decoder.decode(contents);
+                if (!contentsString.split('\n')[1].endsWith('Off')) {
+                    gpusToPoll += `${gpu} `
+                }
+            }
+    
+            // Set the argv to poll awake GPUs only.
+            let path = GLib.find_program_in_path('nvidia-smi');
+            this._argv[2] = `for id in ${gpusToPoll} ; do ${path} ` +
+                '--query-gpu=name,temperature.gpu,display_mode --format=csv,noheader --id=$id ; done';
+            super.execute(callback);
+        } catch (e) {
+            console.error(e);
+        }
     }
 
     get temp() {


### PR DESCRIPTION
- [x] Only poll NVIDIA GPUs which are awake.
- [ ] Slow down poll rate if a GPU is eligible to sleep.
- [ ] Optional: Show 0° instead of a warning logo if the GPU was selected? (I don't think this is a good idea to be honest and will require some work).