### PR TITLE
rename “sudo” option as “pkexec” since sudo was replaced with pkexec

### DIFF
--- a/freon@UshakovVasilii_Github.yahoo.com/freeipmiUtil.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/freeipmiUtil.js
@@ -11,7 +11,7 @@ export default class FreeipmiUtil extends CommandLineUtil {
         // --comma-separated-output: pseudo csv output format, splitting on comma may be good enough for the values we read.
         this._argv = path ? [path, '--comma-separated-output'] : null;
 
-        if (this._argv && exec_method === 'sudo')
+        if (this._argv && exec_method === 'pkexec')
         {
             const pkexec_path = GLib.find_program_in_path('pkexec');
             this._argv = pkexec_path ? [pkexec_path].concat(this._argv) : null;

--- a/freon@UshakovVasilii_Github.yahoo.com/prefs.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/prefs.js
@@ -93,7 +93,7 @@ var FreonPrefsWidget = new GObject.registerClass(class Freon_FreonPrefsWidget ex
         this._addComboBox({
             items : {
                 'direct' : _('Direct'),
-                'sudo' : 'sudo' },
+                'pkexec' : 'pkexec' },
             key: 'exec-method-freeipmi', y : i++, x : j + 1,
             label: ''
         });


### PR DESCRIPTION
rename “sudo” option as “pkexec” since sudo was replaced with pkexec

Actually the pkexec option is broken because pkexec cannot replace sudo, they are not the same tools and they do not do the same things, but that's out of the topic of this PR, see:

- https://github.com/UshakovVasilii/gnome-shell-extension-freon/issues/272