### PR TITLE
ask user to install a pkexec policy when running freeipmi with pkexec

### DIFF
--- a/freon@UshakovVasilii_Github.yahoo.com/extension.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/extension.js
@@ -255,7 +255,17 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
 
     _initFreeipmiUtility() {
         if (this._settings.get_boolean('use-generic-freeipmi'))
-            this._utils.freeipmi = new FreeipmiUtil(this._settings.get_string('exec-method-freeipmi'));
+        {
+            let exec_method = this._settings.get_string('exec-method-freeipmi');
+            try {
+                this._utils.freeipmi = new FreeipmiUtil(exec_method);
+            } catch (e) {
+                if (exec_method != 'direct') {
+                    this._settings.set_string('exec-method-freeipmi', 'direct');
+                    this._freeipmiUtilityChanged();
+                }
+            }
+        }
     }
 
     _destroyFreeipmiUtility() {

--- a/freon@UshakovVasilii_Github.yahoo.com/freeipmiUtil.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/freeipmiUtil.js
@@ -1,6 +1,7 @@
 import GLib from 'gi://GLib';
 
 import CommandLineUtil from './commandLineUtil.js';
+import PkexecUtil from './pkexecUtil.js';
 
 export default class FreeipmiUtil extends CommandLineUtil {
 
@@ -13,6 +14,10 @@ export default class FreeipmiUtil extends CommandLineUtil {
 
         if (this._argv && exec_method === 'sudo')
         {
+            let pkexecUtil = new PkexecUtil('ipmi-sensors');
+            if (!pkexecUtil.checkOrInstall()) {
+                throw 'cannot run ipmi-sensors with pkexec';
+            }
             const pkexec_path = GLib.find_program_in_path('pkexec');
             this._argv = pkexec_path ? [pkexec_path].concat(this._argv) : null;
         }

--- a/freon@UshakovVasilii_Github.yahoo.com/pkexecUtil.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/pkexecUtil.js
@@ -1,0 +1,66 @@
+import GLib from 'gi://GLib';
+import Gio from 'gi://Gio';
+
+export default class PkexecUtil {
+    constructor(name) {
+        this._name = name;
+        this._policy = 'com.github.UshakovVasilii.freon.' + name + '.policy';
+        this._actions = '/usr/share/polkit-1/actions'
+        this._pkexec = GLib.find_program_in_path('pkexec');
+        // Currently hardcoded in policy file.
+        this._bin = '/usr/sbin/' + name;
+		this._dir = this.dir();
+    }
+
+    dir() {
+        let uri = (new Error()).stack.split('\n')[1];
+        if (!uri.startsWith('install@file://')) {
+            return null;
+        }
+        return Gio.File.new_for_path(uri.substring(15)).get_parent().get_path();
+    }
+
+    available_pkexec() {
+        return !!this._pkexec;
+    }
+
+    available_bin() {
+        return GLib.find_program_in_path(this._name) == this._bin;
+    }
+
+    installed() {
+        return GLib.file_test(this._actions + '/' + this._policy, GLib.FileTest.EXISTS);
+    }
+
+    run(command) {
+        return GLib.spawn_command_line_sync(this._pkexec + ' ' + command);
+    }
+
+    install() {
+        try {
+            this.run('install "' + this._dir + '/policies/' + this._policy + '" ' + this._actions);
+        } catch(e) {}
+        if (!this.installed())
+        {
+            log('[FREON] failed to install ' + this._name + ' pkexec policy');
+            return false;
+        }
+        return true;
+    }
+
+    checkOrInstall() {
+        if (!this.available_pkexec()) {
+            log('[FREON] pkexec is not available');
+            return false;
+        }
+        if (!this.available_bin()) {
+            log('[FREON] ' + this._bin + ' is not available');
+            return false;
+        }
+        if (!this.installed()) {
+            log('[FREON] ' + this._name + ' policy is not installed yet');
+            return this.install();
+        }
+        return true;
+    }
+}

--- a/freon@UshakovVasilii_Github.yahoo.com/policies/com.github.UshakovVasilii.freon.ipmi-sensors.policy
+++ b/freon@UshakovVasilii_Github.yahoo.com/policies/com.github.UshakovVasilii.freon.ipmi-sensors.policy
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+	"http://www.freedesktop.org/standards/PolicyKit/1/policyconfig.dtd">
+<policyconfig>
+	<vendor>Vasilii Ushakov</vendor>
+	<vendor_url>https://github.com/UshakovVasilii</vendor_url>
+
+	<action id="com.github.UshakovVasilii.freon.ipmi-sensors.policy">
+		<description>Run ipmi-sensors</description>
+		<message>No Authorization required to run ipmi-sensors.</message>
+		<defaults>
+			<allow_any>yes</allow_any>
+			<allow_inactive>yes</allow_inactive>
+			<allow_active>yes</allow_active>
+		</defaults>
+		<annotate key="org.freedesktop.policykit.exec.path">/usr/sbin/ipmi-sensors</annotate>
+	</action>
+</policyconfig>


### PR DESCRIPTION
A `PkexecUtil` class is provided to be reused by other tools like `smartctl` or `nvme-cli` in the future.

This implements a way to ship a pkexec policy file and to ask the user to install it when missing, once `pkexec` exec method is selected.

This provides a policy file for `ipmi-sensors` for now.

For now the `/usr/sbin/` prefix for super user binaries is hardcoded, I'm not sure we can generate a policy file on the fly, so maybe there is no good way to not hardcode this.

If setting up pkexec fails (because either pkexec is not found, the super user binary (here `/usr/sbin/ipmi-sensors`) is not found, or the user did did not gave the right password, the settings is reset to `direct` to avoid endless password requests).

One known bug is that when the setting is reset on failure, the preferences window do not update, but closing the preference window and reopening it shows the setting is properly reset.

I'm not fluent in javascript so there may be better ways to do it.

I believe it's better to merge this than to wait for something better, because right now the current code in master annoys the user with endless password requests, those password requests taking priority and preventing to reset the option.

Fixes #272:

- https://github.com/UshakovVasilii/gnome-shell-extension-freon/issues/272