### PR TITLE
fix pkexec support and do not call pkexec at all if the install dir is not found

### DIFF
--- a/freon@UshakovVasilii_Github.yahoo.com/pkexecUtil.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/pkexecUtil.js
@@ -9,15 +9,17 @@ export default class PkexecUtil {
         this._pkexec = GLib.find_program_in_path('pkexec');
         // Currently hardcoded in policy file.
         this._bin = '/usr/sbin/' + name;
-		this._dir = this.dir();
+        this._dir = this.dir();
     }
 
     dir() {
         let uri = (new Error()).stack.split('\n')[1];
-        if (!uri.startsWith('install@file://')) {
+        let prefix = this.constructor.name + '@file://'
+        if (!uri.startsWith(prefix)) {
+            log('[FREON] failed to guess extension directory');
             return null;
         }
-        return Gio.File.new_for_path(uri.substring(15)).get_parent().get_path();
+        return Gio.File.new_for_path(uri.substring(prefix.length)).get_parent().get_path();
     }
 
     available_pkexec() {
@@ -37,6 +39,11 @@ export default class PkexecUtil {
     }
 
     install() {
+        if (!this._dir)
+        {
+            log('[FREON] cannot find ' + this._name + ' pkexec policy file ' + this._policy);
+            return false;
+        }
         try {
             this.run('install "' + this._dir + '/policies/' + this._policy + '" ' + this._actions);
         } catch(e) {}


### PR DESCRIPTION
fix pkexec support and do not call pkexec at all if the install dir is not found

- Fix pkexec support. For some forgotten reasons (maybe a rewrite?) the extension was mistakenly looking for `install` as a class name, so it couldn't parse the stack properly and then couldn't guess the install dir and then couldn't find the policy file. To avoid such mistake to happen again if some rewrite happens one day, the class name is not hardcoded but requested from javascript interpreter.
- Do not call pkexec at all if the install dir is not found.

The combination of the presence of that “broken lookup” bug and the lack of that “not found” test should have been wrong but not that bad: it should have just let pkexec ask the user to install a file that doesn't exist, then fail and reset the option and not annoy the user more than simply failing to use the option.

**BUT** GNOME Shell has a very nasty bug where sometime all new windows are opened in background, and when the bug occurs, this also affects the pkexec window, meaning the desktop freeze waiting for the user to input the password, but without displaying the password prompt to the user. This is not a bug in this extension, this is a bug in GNOME Shell, and GNOME Shell people requiring to use pkexec instead of non-interactive sudo while the said bug exists is just making them put the user at risk of locking the user desktop without any way to unlock it (unless you open a tty or connect from another computer through ssh, and kill pkexec).

After this patch is merged, if GNOME shell locks the user desktop because of the said bug, it will be 100% GNOME shell developer's fault, not ours, as it should be.