### PR TITLE
Support for GNOME 46

### DIFF
--- a/freon@UshakovVasilii_Github.yahoo.com/extension.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/extension.js
@@ -50,7 +50,11 @@ function _makeLogFunction(prefix) {
     }
 }
 
-const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extends PanelMenu.Button {
+class FreonMenuButton extends PanelMenu.Button {
+
+    static {
+        GObject.registerClass(this);
+    }
 
     constructor(uuid, path, settings) {
         super(0);
@@ -112,7 +116,7 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
             this._createInitialIcon();
         }
 
-        this.add_actor(this._menuLayout);
+        this.add_child(this._menuLayout);
 
         this._settingChangedSignals = [];
 
@@ -176,7 +180,7 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
             if(gicon)
                 i.gicon = gicon;
 
-            this._menuLayout.add(i);
+            this._menuLayout.add_child(i);
         }
         let l = new St.Label({
             text: '\u26a0',  // ⚠, warning
@@ -185,13 +189,13 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
         l.set_style_class_name(showIcon ? 'freon-panel-icon-label' : 'freon-panel-no-icon-label');
 
         this._hotLabels[s] = l;
-        this._menuLayout.add(l);
+        this._menuLayout.add_child(l);
     }
 
     _createInitialIcon() {
         this._initialIcon = new St.Icon({ style_class: 'system-status-icon'});
         this._initialIcon.gicon = this._sensorIcons['gpu-temperature'];
-        this._menuLayout.add(this._initialIcon);
+        this._menuLayout.add_child(this._initialIcon);
     }
 
     _rerender(){
@@ -200,7 +204,7 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
     }
 
     _positionInPanelChanged(){
-        this.container.get_parent().remove_actor(this.container);
+        this.container.get_parent().remove_child(this.container);
 
         // small HACK with private boxes :)
         let boxes = {
@@ -976,7 +980,7 @@ const FreonMenuButton = GObject.registerClass(class Freon_FreonMenuButton extend
     get positionInPanel(){
         return this._settings.get_string('position-in-panel');
     }
-});
+}
 
 export default class extends Extension {
 

--- a/freon@UshakovVasilii_Github.yahoo.com/freonItem.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/freonItem.js
@@ -4,7 +4,11 @@ import St from 'gi://St';
 
 import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
 
-export default GObject.registerClass(class FreonItem extends PopupMenu.PopupBaseMenuItem {
+export default class FreonItem extends PopupMenu.PopupBaseMenuItem {
+
+    static {
+        GObject.registerClass(this);
+    }
 
     constructor(gIcon, key, label, value, displayName) {
         super();
@@ -13,10 +17,10 @@ export default GObject.registerClass(class FreonItem extends PopupMenu.PopupBase
         this._gIcon = gIcon;
 
         this._labelActor = new St.Label({text: displayName ? displayName : label, x_align: Clutter.ActorAlign.CENTER, x_expand: true});
-        this.actor.add(new St.Icon({ style_class: 'popup-menu-icon', gicon : gIcon}));
+        this.actor.add_child(new St.Icon({ style_class: 'popup-menu-icon', gicon : gIcon}));
         this.actor.add_child(this._labelActor);
         this._valueLabel = new St.Label({text: value});
-        this.actor.add(this._valueLabel);
+        this.actor.add_child(this._valueLabel);
     }
 
     set main(main) {
@@ -46,4 +50,4 @@ export default GObject.registerClass(class FreonItem extends PopupMenu.PopupBase
     set value(value) {
         this._valueLabel.text = value;
     }
-});
+}

--- a/freon@UshakovVasilii_Github.yahoo.com/metadata.json
+++ b/freon@UshakovVasilii_Github.yahoo.com/metadata.json
@@ -1,5 +1,5 @@
 {
-  "shell-version": ["45"],
+  "shell-version": ["45", "46"],
   "uuid": "freon@UshakovVasilii_Github.yahoo.com",
   "name": "Freon",
   "description": "Shows CPU temperature, disk temperature, video card temperature (NVIDIA/Catalyst/Bumblebee&NVIDIA), voltage and fan RPM (forked from xtranophilist/gnome-shell-extension-sensors)",


### PR DESCRIPTION
The Functions add and add_actor got removed in GNOME 46.

This fixes the error mentioned in #280

I did not test the changes on GNOME 45 but I guess it should still work.