### PR TITLE
 getSmartData(...) temperature is undefined #209

### DIFF
--- a/freon@UshakovVasilii_Github.yahoo.com/smartctlUtil.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/smartctlUtil.js
@@ -39,6 +39,10 @@ export default class SmartctlUtil {
             if (attributes["smartctl"]["exit_status"] != 0)
                 return null;
 
+            if(!attributes.temperature) {
+              return null;
+            }
+
             return {
                 label: info["model_name"],
                 temp: parseFloat(attributes.temperature.current)


### PR DESCRIPTION
 This will ignore any drive without a temperature. e.g.  drives connected via usb.