### PR TITLE
Mark compatible with GNOME Shell 47

### DIFF
--- a/freon@UshakovVasilii_Github.yahoo.com/metadata.json
+++ b/freon@UshakovVasilii_Github.yahoo.com/metadata.json
@@ -1,5 +1,5 @@
 {
-  "shell-version": ["45", "46"],
+  "shell-version": ["45", "46", "47"],
   "uuid": "freon@UshakovVasilii_Github.yahoo.com",
   "name": "Freon",
   "description": "Shows CPU temperature, disk temperature, video card temperature (NVIDIA/Catalyst/Bumblebee&NVIDIA), voltage and fan RPM (forked from xtranophilist/gnome-shell-extension-sensors)",


### PR DESCRIPTION
GNOME 47 is scheduled for release on Wednesday.

I did a very simple smoketest with this change on Debian with gnome-shell 47.rc . I didn't have sensors configured in my VM so it wasn't a complete test but I don't think the changes from 46 to 47 were very disruptive.

See also https://gjs.guide/extensions/upgrading/gnome-shell-47.html