### PR TITLE
Remote timeout on destroy for _positionInPanelChanged()

### DIFF
--- a/freon@UshakovVasilii_Github.yahoo.com/extension.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/extension.js
@@ -175,8 +175,7 @@ class FreonMenuButton extends PanelMenu.Button {
             // readd to update queue
             return true;
         });
-
-        GLib.timeout_add(GLib.PRIORITY_DEFAULT, 500, () => {
+        this._positionInPanelChangedTimeoutId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 500, () => {
             this._positionInPanelChanged();
             return false; // 只执行一次
         });
@@ -534,6 +533,7 @@ class FreonMenuButton extends PanelMenu.Button {
 
         GLib.Source.remove(this._timeoutId);
         GLib.Source.remove(this._updateUITimeoutId);
+        GLib.Source.remove(this._positionInPanelChangedTimeoutId);
 
         for (let signal of this._settingChangedSignals){
             this._settings.disconnect(signal);


### PR DESCRIPTION
This extension got rejected because of a missing timeout clearence. (https://extensions.gnome.org/review/65888)
This PR fix this, reported on #301