### PR TITLE
Mark compatible with GNOME Shell 50

### DIFF
--- a/freon@UshakovVasilii_Github.yahoo.com/metadata.json
+++ b/freon@UshakovVasilii_Github.yahoo.com/metadata.json
@@ -1,5 +1,5 @@
 {
-  "shell-version": ["45", "46", "47", "48", "49"],
+  "shell-version": ["45", "46", "47", "48", "49", "50"],
   "uuid": "freon@UshakovVasilii_Github.yahoo.com",
   "name": "Freon",
   "description": "Shows CPU temperature, disk temperature, video card temperature (NVIDIA/Catalyst/Bumblebee&NVIDIA), voltage and fan RPM (forked from xtranophilist/gnome-shell-extension-sensors)",


### PR DESCRIPTION
There don’t seem to be incompatible changes in GNOME 50: https://gjs.guide/extensions/upgrading/gnome-shell-50.html

I’ve built version 60 with this patch applied, and it seems to work fine in GNOME 50 on Fedora Linux 44 (pre-beta).