### PR TITLE
Lifecycle, perf, and security hardening (GS 45-50)

### DIFF
--- a/freon@UshakovVasilii_Github.yahoo.com/aticonfigUtil.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/aticonfigUtil.js
@@ -15,24 +15,28 @@ export default class AticonfigUtil extends CommandLineUtil {
                   Sensor 0: Temperature - 37.00 C
     */
     get temp() {
-        if(!this._output)
+        if (!this._output)
             return [];
         let label = null;
         let temp = null;
         for (let line of this._output) {
-            if(!line)
+            if (!line)
                 continue;
             let r;
-            if(line.indexOf('Adapter') > 0)
-                label = (r = /Adapter \- (.*)/.exec(line)) ? r[1] : undefined;
-            if(line.indexOf('Temperature') > 0)
-                temp = (r = /Temperature \- (\d{1,3}.\d{1,2})/.exec(line)) ? parseFloat(r[1]) : undefined;
+            if (line.indexOf('Adapter') > 0) {
+                r = /Adapter \- (.*)/.exec(line);
+                if (r) label = r[1];
+            }
+            if (line.indexOf('Temperature') > 0) {
+                r = /Temperature\s*-\s*([\d.]+)/.exec(line);
+                if (r) temp = parseFloat(r[1]);
+            }
         }
 
-        if(!label || !temp)
+        if (!label || !Number.isFinite(temp))
             return [];
 
-        return [{ label : label.trim(), temp : temp}];
+        return [{ label: label.trim(), temp: temp }];
     }
 
-};
+}

--- a/freon@UshakovVasilii_Github.yahoo.com/batteryUtil.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/batteryUtil.js
@@ -4,13 +4,23 @@ import GLib from 'gi://GLib';
 
 export default class BatteryUtil {
 
-    constructor(callback) {
+    constructor() {
         this._bat_path = [];    // Filesystem paths to batteries
+        this._updated = false;
         this._find_batteries();
+        this._updated = true;
     }
 
     get available(){
         return (this._bat_path[0]) ? true : false;
+    }
+
+    get updated() {
+        return this._updated;
+    }
+
+    set updated(updated) {
+        this._updated = updated;
     }
 
     get energy() {
@@ -36,7 +46,7 @@ export default class BatteryUtil {
             power /= 1000000.00;
 
             let state = this._get_sensor_data(bat_path, "status");
-            if (state.startsWith("Dis"))
+            if (state && state.startsWith("Dis"))
                 power *= -1;
 
             let bat_name = bat_path.split('/').pop();
@@ -71,6 +81,8 @@ export default class BatteryUtil {
     }
 
     execute(callback) {
+        this._updated = true;
+        if (callback) callback();
     }
 
     _find_batteries() {
@@ -107,4 +119,4 @@ export default class BatteryUtil {
         return "";
     }
 
-};
+}

--- a/freon@UshakovVasilii_Github.yahoo.com/batteryUtil.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/batteryUtil.js
@@ -1,10 +1,11 @@
+import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
 
 
 export default class BatteryUtil {
 
     constructor(callback) {
-        this._bat_path = [];    // Path to batteries for cat
+        this._bat_path = [];    // Filesystem paths to batteries
         this._find_batteries();
     }
 
@@ -73,38 +74,37 @@ export default class BatteryUtil {
     }
 
     _find_batteries() {
-        const cmd = `find /sys/class/power_supply/ -type l -name "BAT*"`
-        let cmd_res = []
+        const power_supply = Gio.File.new_for_path('/sys/class/power_supply');
+        let enumerator;
         try {
-            cmd_res = GLib.spawn_command_line_sync(cmd)
+            enumerator = power_supply.enumerate_children(
+                'standard::name',
+                Gio.FileQueryInfoFlags.NOFOLLOW_SYMLINKS,
+                null);
         } catch (e) {
-            logError(e, `[FREON] failed to execute "find"`)
+            logError(e, '[FREON] failed to enumerate /sys/class/power_supply');
+            return;
         }
-        if (cmd_res[0] == true) {
-            this._bat_path = new TextDecoder().decode( cmd_res[1] ).split('\n')
-            let trailing_path = this._bat_path.pop()
-            if (trailing_path.length > 1)   // remove empty trailing Elements
-                this._bat_path.push(trailing_path)
+
+        let info;
+        while ((info = enumerator.next_file(null)) != null) {
+            let name = info.get_name();
+            if (name.startsWith('BAT'))
+                this._bat_path.push('/sys/class/power_supply/' + name);
         }
-        else {
-            print(`"find" returned an error: ${cmd_res[2]}`)
-        }
+        enumerator.close(null);
     }
 
     _get_sensor_data(bat_path, sensor) {
-        const path = `${bat_path}/${sensor}`
-        const cmd = "cat " + path;
-
-        let cmd_res = []
+        const path = `${bat_path}/${sensor}`;
         try {
-            cmd_res = GLib.spawn_command_line_sync(cmd)
+            let [ok, contents] = GLib.file_get_contents(path);
+            if (ok)
+                return new TextDecoder().decode(contents);
         } catch (e) {
-            logError(e, `[FREON] failed to execute "cat"`)
+            logError(e, `[FREON] failed to read ${path}`);
         }
-        if (cmd_res[0] == true)
-            return new TextDecoder().decode(cmd_res[1])
-        else
-            return ""
+        return "";
     }
 
 };

--- a/freon@UshakovVasilii_Github.yahoo.com/bumblebeeNvidiaUtil.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/bumblebeeNvidiaUtil.js
@@ -1,6 +1,8 @@
 import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
 
+import { gettext as _ } from 'resource:///org/gnome/shell/extensions/extension.js';
+
 import CommandLineUtil from './commandLineUtil.js';
 
 export default class BumblebeeNvidiaUtil extends CommandLineUtil {
@@ -17,74 +19,89 @@ export default class BumblebeeNvidiaUtil extends CommandLineUtil {
         let virtualDisplay = ':8';
 
         let bumblebeeConfPath = '/etc/bumblebee/bumblebee.conf';
-        if(GLib.file_test(bumblebeeConfPath, GLib.FileTest.EXISTS)){
+        if (GLib.file_test(bumblebeeConfPath, GLib.FileTest.EXISTS)) {
             let configFile = Gio.File.new_for_path(bumblebeeConfPath);
-            let contents = configFile.load_contents(null);
-            if (contents[0]) {
-                let pattern = /^VirtualDisplay=.*$/m
-                let match = new String(pattern.exec(new String(contents)));
-                virtualDisplay = match.substr(16);
+            let [ok, contents] = configFile.load_contents(null);
+            if (ok) {
+                let text = new TextDecoder().decode(contents);
+                let m = /^VirtualDisplay=(.*)$/m.exec(text);
+                if (m) virtualDisplay = m[1].trim();
             }
         }
         let lockFilePath = '/tmp/.X' + virtualDisplay + '-lock';
-        this._lockMonitor = Gio.File.new_for_path(
-            lockFilePath).monitor_file(Gio.FileMonitorFlags.NONE, null
-        );
+        this._lockMonitor = Gio.File.new_for_path(lockFilePath)
+            .monitor_file(Gio.FileMonitorFlags.NONE, null);
         this._lockMonitor.id = this._lockMonitor.connect(
             'changed', this._statusChanged.bind(this)
         );
 
         // Check if the lock file already exists
         // (needed when NVIDIA card is already in use at that point)
-        if(GLib.file_test(lockFilePath, GLib.FileTest.EXISTS)){
+        if (GLib.file_test(lockFilePath, GLib.FileTest.EXISTS)) {
             this._detectLabel();
             this._active = true;
         }
     }
 
     _detectLabel() {
+        if (!this._path)
+            return;
         // optirun nvidia-smi -L
         // GPU 0: GeForce GT 525M (UUID: GPU-...)
-        let [, stdout] = GLib.spawn_command_line_sync(this._path + " nvidia-smi -L");
-        let lines = new TextDecoder().decode(stdout).split('\n');
-        for (let line of lines){
-            let match = /.*GPU [\d]:([\w\d\ ]+).*/.exec(line);
-            if(match){
-                this._label = match[1];
-                if(this._label)
-                    this._label = this._label.trim();
-                break;
-            }
+        let proc;
+        try {
+            proc = Gio.Subprocess.new([this._path, 'nvidia-smi', '-L'],
+                Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_PIPE);
+        } catch (e) {
+            logError(e, '[FREON] optirun nvidia-smi -L spawn failed');
+            return;
         }
+        proc.communicate_utf8_async(null, null, (p, res) => {
+            try {
+                let [, stdout] = p.communicate_utf8_finish(res);
+                for (let line of (stdout || '').split('\n')) {
+                    let match = /.*GPU [\d]:([\w\d\ ]+).*/.exec(line);
+                    if (match) {
+                        this._label = match[1].trim();
+                        break;
+                    }
+                }
+            } catch (e) {
+                logError(e, '[FREON] optirun nvidia-smi -L parse failed');
+            }
+        });
     }
 
     _statusChanged(monitor, a_file, other_file, event_type) {
         if (event_type == Gio.FileMonitorEvent.CREATED) {
-            if(this._argv && !this._label)
+            if (this._argv && !this._label)
                 this._detectLabel();
             this._active = true;
-        } else if (event_type ==  Gio.FileMonitorEvent.DELETED) {
+        } else if (event_type == Gio.FileMonitorEvent.DELETED) {
             this._active = false;
         }
     }
 
     execute(callback) {
-        if(this._active)
+        if (this._active) {
             super.execute(callback);
-        else
+        } else {
             this._output = [];
+            this._updated = true;
+            if (callback) callback();
+        }
     }
 
     get temp() {
-        let key = 'bumblebee-nvidia'
+        let key = 'bumblebee-nvidia';
         let label = this._label ? this._label : _('Bumblebee + NVIDIA');
-        if(this._active && this._output){
+        if (this._active && this._output) {
             //         GPU Current Temp            : 37 C
             for (let line of this._output) {
-                if(!line)
+                if (!line)
                     continue;
                 let r;
-                if(line.indexOf('GPU Current Temp') > 0)
+                if (line.indexOf('GPU Current Temp') > 0)
                     return [{
                         label: key,
                         temp: (r = /[\s]*GPU Current Temp[\s]*:[\s]*(\d{1,3}).*/.exec(line)) ? parseFloat(r[1]) : null,
@@ -92,13 +109,21 @@ export default class BumblebeeNvidiaUtil extends CommandLineUtil {
                     }];
             }
         }
-        return [{label: key, temp: null, displayName: label}];
+        return [{ label: key, temp: null, displayName: label }];
     }
 
-    destroy(){
+    destroy() {
         super.destroy();
-        this._lockMonitor.disconnect(this._lockMonitor.id);
-        this._lockMonitor.cancel();
+        if (this._lockMonitor) {
+            try {
+                if (this._lockMonitor.id)
+                    this._lockMonitor.disconnect(this._lockMonitor.id);
+            } catch (e) {
+                // ignore
+            }
+            this._lockMonitor.cancel();
+            this._lockMonitor = null;
+        }
     }
 
-};
+}

--- a/freon@UshakovVasilii_Github.yahoo.com/bumblebeeNvidiaUtil.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/bumblebeeNvidiaUtil.js
@@ -56,7 +56,8 @@ export default class BumblebeeNvidiaUtil extends CommandLineUtil {
             logError(e, '[FREON] optirun nvidia-smi -L spawn failed');
             return;
         }
-        proc.communicate_utf8_async(null, null, (p, res) => {
+        proc.communicate_utf8_async(null, this._cancellable, (p, res) => {
+            if (this._destroyed) return;
             try {
                 let [, stdout] = p.communicate_utf8_finish(res);
                 for (let line of (stdout || '').split('\n')) {
@@ -67,7 +68,8 @@ export default class BumblebeeNvidiaUtil extends CommandLineUtil {
                     }
                 }
             } catch (e) {
-                logError(e, '[FREON] optirun nvidia-smi -L parse failed');
+                if (!e.matches?.(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED))
+                    logError(e, '[FREON] optirun nvidia-smi -L parse failed');
             }
         });
     }

--- a/freon@UshakovVasilii_Github.yahoo.com/bumblebeeNvidiaUtil.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/bumblebeeNvidiaUtil.js
@@ -45,8 +45,10 @@ export default class BumblebeeNvidiaUtil extends CommandLineUtil {
     _detectLabel() {
         // optirun nvidia-smi -L
         // GPU 0: GeForce GT 525M (UUID: GPU-...)
-        for (let line of GLib.spawn_command_line_sync(this._path + " nvidia-smi -L")){
-        let match = /.*GPU [\d]:([\w\d\ ]+).*/.exec(line);
+        let [, stdout] = GLib.spawn_command_line_sync(this._path + " nvidia-smi -L");
+        let lines = new TextDecoder().decode(stdout).split('\n');
+        for (let line of lines){
+            let match = /.*GPU [\d]:([\w\d\ ]+).*/.exec(line);
             if(match){
                 this._label = match[1];
                 if(this._label)
@@ -96,6 +98,7 @@ export default class BumblebeeNvidiaUtil extends CommandLineUtil {
     destroy(){
         super.destroy();
         this._lockMonitor.disconnect(this._lockMonitor.id);
+        this._lockMonitor.cancel();
     }
 
 };

--- a/freon@UshakovVasilii_Github.yahoo.com/commandLineUtil.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/commandLineUtil.js
@@ -2,30 +2,41 @@ import Gio from 'gi://Gio';
 
 export default class CommandLineUtil {
 
-    constructor(){
+    constructor() {
         this._argv = null;
         this._updated = false;
+        this._cancellable = new Gio.Cancellable();
+        this._destroyed = false;
     }
 
     execute(callback) {
-        try{
+        if (this._destroyed || !this._argv) {
+            if (callback) callback();
+            return;
+        }
+        try {
             this._callback = callback;
 
             let proc = Gio.Subprocess.new(this._argv,
                                           Gio.SubprocessFlags.STDOUT_PIPE |
                                           Gio.SubprocessFlags.STDERR_PIPE);
 
-            proc.communicate_utf8_async(null, null, (proc, result) => {
+            proc.communicate_utf8_async(null, this._cancellable, (proc, result) => {
                 try {
                     let [, stdout, stderr] = proc.communicate_utf8_finish(result);
+
+                    if (this._destroyed)
+                        return;
 
                     this._output = stdout ? stdout.split('\n') : [];
                     this._error_output = stderr ? stderr.split('\n') : [];
                 } catch (e) {
-                    logError(e);
+                    if (!e.matches?.(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED))
+                        logError(e);
                 } finally {
-                    callback();
                     this._updated = true;
+                    if (!this._destroyed && callback)
+                        callback();
                 }
             });
         } catch(e){
@@ -46,7 +57,15 @@ export default class CommandLineUtil {
     }
 
     destroy(){
+        this._destroyed = true;
+        if (this._cancellable) {
+            this._cancellable.cancel();
+            this._cancellable = null;
+        }
         this._argv = null;
+        this._output = null;
+        this._error_output = null;
+        this._callback = null;
     }
 
-};
+}

--- a/freon@UshakovVasilii_Github.yahoo.com/extension.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/extension.js
@@ -27,12 +27,13 @@ import BatteryUtil from './batteryUtil.js';
 
 import FreonItem from './freonItem.js';
 
+const _STACK_RE = /(?:(?:[^<.]+<\.)?([^@]+))?@(.+):(\d+):\d+/;
+
 function _makeLogFunction(prefix) {
     return msg => {
         // Grab the second line of a stack trace, i.e. caller of debug()
-        let regex = /(?:(?:[^<.]+<\.)?([^@]+))?@(.+):(\d+):\d+/g;
         let trace = ((msg.stack) ? msg : new Error()).stack.split('\n')[1];
-        let [m, func, file, line] = regex.exec(trace);
+        let [m, func, file, line] = _STACK_RE.exec(trace);
         file = GLib.path_get_basename(file);
 
         let hdr = [file, func, line].filter(k => (k)).join(':');
@@ -61,9 +62,10 @@ class FreonMenuButton extends PanelMenu.Button {
         super(0);
 
         this._extension_uuid = uuid;
+        this._extension_path = path;
         this._settings = settings;
 
-        var _debugFunc = _makeLogFunction('DEBUG');
+        const _debugFunc = _makeLogFunction('DEBUG');
         this.debug = this._settings.get_boolean('debug') ? _debugFunc : () => {};
 
         this._settings.connect('changed::debug', () => {
@@ -300,10 +302,11 @@ class FreonMenuButton extends PanelMenu.Button {
         if (exec_method != 0) {
             try {
                 if (exec_method == 1)
-                    this._utils.freeipmi = new FreeipmiUtil("direct");
+                    this._utils.freeipmi = new FreeipmiUtil("direct", this._extension_path);
                 else if (exec_method == 2)
-                    this._utils.freeipmi = new FreeipmiUtil("pkexec");
+                    this._utils.freeipmi = new FreeipmiUtil("pkexec", this._extension_path);
             } catch (e) {
+                logError(e, '[FREON] freeipmi init failed; falling back to direct');
                 if (exec_method == 2) {
                     this._settings.set_int('freeimpi-selected', 1);
                     this._freeipmiUtilityChanged();
@@ -500,12 +503,16 @@ class FreonMenuButton extends PanelMenu.Button {
     }
 
     _updateTimeChanged(){
-        GLib.Source.remove(this._timeoutId);
+        if (this._timeoutId) {
+            GLib.Source.remove(this._timeoutId);
+            this._timeoutId = 0;
+        }
         this._addTimer();
     }
 
     _addTimer(){
-        this._timeoutId = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, this._settings.get_int('update-time'), () => {
+        const interval = Math.max(1, this._settings.get_int('update-time'));
+        this._timeoutId = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, interval, () => {
             this._querySensors();
             // readd to update queue
             return true;
@@ -532,10 +539,18 @@ class FreonMenuButton extends PanelMenu.Button {
 
         this._destroyBatteryUtility();
 
-        GLib.Source.remove(this._timeoutId);
-        GLib.Source.remove(this._updateUITimeoutId);
-        if (this._positionInPanelChangedTimeoutId)
+        if (this._timeoutId) {
+            GLib.Source.remove(this._timeoutId);
+            this._timeoutId = 0;
+        }
+        if (this._updateUITimeoutId) {
+            GLib.Source.remove(this._updateUITimeoutId);
+            this._updateUITimeoutId = 0;
+        }
+        if (this._positionInPanelChangedTimeoutId) {
             GLib.Source.remove(this._positionInPanelChangedTimeoutId);
+            this._positionInPanelChangedTimeoutId = 0;
+        }
 
         for (let signal of this._settingChangedSignals){
             this._settings.disconnect(signal);
@@ -555,7 +570,7 @@ class FreonMenuButton extends PanelMenu.Button {
     _updateUI(needUpdate = false){
         for (let sensor of Object.values(this._utils)) {
             if (sensor.available && sensor.updated) {
-                this.debug(sensor + ' updated');
+                this.debug(`${sensor.constructor.name} updated`);
                 sensor.updated = false;
                 needUpdate = true;
             }
@@ -862,7 +877,7 @@ class FreonMenuButton extends PanelMenu.Button {
         this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
         let wiki = new PopupMenu.PopupBaseMenuItem();
-        wiki.actor.add_child(new St.Label({ text: _("Go to the Freon wiki"), x_align: Clutter.ActorAlign.START, x_expand: true }));
+        wiki.add_child(new St.Label({ text: _("Go to the Freon wiki"), x_align: Clutter.ActorAlign.START, x_expand: true }));
         wiki.connect('activate', () => {
             Util.spawn(["xdg-open", "https://github.com/UshakovVasilii/gnome-shell-extension-freon/wiki"]);
         });
@@ -870,7 +885,7 @@ class FreonMenuButton extends PanelMenu.Button {
         this.menu.addMenuItem(wiki);
 
         let settings = new PopupMenu.PopupBaseMenuItem();
-        settings.actor.add_child(new St.Label({ text: _("Sensor Settings"), x_align: Clutter.ActorAlign.START, x_expand: true }));
+        settings.add_child(new St.Label({ text: _("Sensor Settings"), x_align: Clutter.ActorAlign.START, x_expand: true }));
         settings.connect('activate', () => {
             Util.spawn(["gnome-extensions", "prefs", this._extension_uuid]);
         });
@@ -942,7 +957,7 @@ class FreonMenuButton extends PanelMenu.Button {
                     } else {
                         hotSensors.push(self.key);
 
-                        if (Object.keys(this._hotLabels).length == 0) {
+                        if (Object.keys(this._hotLabels).length == 0 && this._initialIcon) {
                             this._initialIcon.destroy();
                             this._initialIcon = null;
                         }
@@ -971,10 +986,7 @@ class FreonMenuButton extends PanelMenu.Button {
                     if (Object.keys(this._hotLabels).length == 0)
                         this._createInitialIcon();
 
-                    this._settings.set_strv('hot-sensors', hotSensors.filter(
-                        function(item, pos) {
-                            return hotSensors.indexOf(item) == pos;
-                        }));
+                    this._settings.set_strv('hot-sensors', Array.from(new Set(hotSensors)));
                 });
 
                 if (this._hotLabels[key]) {
@@ -990,12 +1002,17 @@ class FreonMenuButton extends PanelMenu.Button {
                         temperatureGroup = new PopupMenu.PopupSubMenuMenuItem(_('Temperature'), true);
                         temperatureGroup.icon.gicon = this._sensorIcons['temperature'];
 
-                        if (!temperatureGroup.status) { // gnome 3.18 and hight
+                        if (!temperatureGroup.status) {
                             temperatureGroup.status = new St.Label({
                                      style_class: 'popup-status-menu-item',
                                      y_expand: true,
                                      y_align: Clutter.ActorAlign.CENTER });
-                            temperatureGroup.actor.insert_child_at_index(temperatureGroup.status, 4);
+                            const triangle = temperatureGroup._triangleBin;
+                            if (triangle && triangle.get_parent() === temperatureGroup) {
+                                temperatureGroup.insert_child_below(temperatureGroup.status, triangle);
+                            } else {
+                                temperatureGroup.add_child(temperatureGroup.status);
+                            }
                         }
 
                         this.menu.addMenuItem(temperatureGroup);

--- a/freon@UshakovVasilii_Github.yahoo.com/extension.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/extension.js
@@ -703,11 +703,10 @@ class FreonMenuButton extends PanelMenu.Button {
         } else {
             let tempMean = 0;
             let tempMax = 0;
+            let sum = 0;
+            let total = 0;
 
             for (let i of tempInfo) {
-                let sum = 0;
-                let total = 0;
-
                 if (i.temp !== null && i.temp >= 0) {
                     total++;
                     sum += i.temp;
@@ -715,10 +714,10 @@ class FreonMenuButton extends PanelMenu.Button {
                     if (i.temp > tempMax)
                         tempMax = i.temp;
                 }
-
-                if (total != 0)
-                    tempMean = sum / total;
             }
+
+            if (total != 0)
+                tempMean = sum / total;
 
             let sensors = [];
 

--- a/freon@UshakovVasilii_Github.yahoo.com/extension.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/extension.js
@@ -170,7 +170,7 @@ class FreonMenuButton extends PanelMenu.Button {
 
         this._addTimer();
         this._updateUI(true);
-        this._updateUITimeoutId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 250, () => {
+        this._updateUITimeoutId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 500, () => {
             this._updateUI();
             // read to update queue
             return true;
@@ -568,7 +568,7 @@ class FreonMenuButton extends PanelMenu.Button {
     }
 
     _fixNames(sensors){
-        let names = [];
+        let names = new Set();
 
         for (let s of sensors){
             if(s.type == 'separator' ||
@@ -580,7 +580,7 @@ class FreonMenuButton extends PanelMenu.Button {
             let name = s.label;
             let i = 1;
 
-            while(names.indexOf(name) >= 0){
+            while(names.has(name)){
                 name = s.label + '-' + i++;
             }
 
@@ -589,7 +589,7 @@ class FreonMenuButton extends PanelMenu.Button {
                 s.label = name;
             }
 
-            names.push(name);
+            names.add(name);
         }
     }
 
@@ -601,74 +601,74 @@ class FreonMenuButton extends PanelMenu.Button {
         let voltageInfo = [];
         let powerInfo = [];
 
+        const showTemp = this._settings.get_boolean('show-temperature');
+        const showRpm = this._settings.get_boolean('show-rotationrate');
+        const showVolt = this._settings.get_boolean('show-voltage');
+        const showPower = this._settings.get_boolean('show-power');
+        const showBattery = this._settings.get_boolean('show-battery-stats');
+
         if (this._utils.sensors && this._utils.sensors.available) {
-            if (this._settings.get_boolean('show-temperature')) {
+            if (showTemp) {
                 sensorsTempInfo = sensorsTempInfo.concat(this._utils.sensors.temp);
                 gpuTempInfo = gpuTempInfo.concat(this._utils.sensors.gpu);
                 driveTempInfo = driveTempInfo.concat(this._utils.sensors.disks);
             }
 
-            if (this._settings.get_boolean('show-rotationrate'))
+            if (showRpm)
                 fanInfo = fanInfo.concat(this._utils.sensors.rpm);
-            if (this._settings.get_boolean('show-voltage'))
+            if (showVolt)
                 voltageInfo = voltageInfo.concat(this._utils.sensors.volt);
-            if (this._settings.get_boolean('show-power')) {
+            if (showPower) {
                 powerInfo = powerInfo.concat(this._utils.sensors.power);
             }
-                
         }
 
         if (this._utils.freeipmi && this._utils.freeipmi.available) {
-            if (this._settings.get_boolean('show-temperature'))
+            if (showTemp)
                 sensorsTempInfo = sensorsTempInfo.concat(this._utils.freeipmi.temp);
-            if (this._settings.get_boolean('show-rotationrate'))
+            if (showRpm)
                 fanInfo = fanInfo.concat(this._utils.freeipmi.rpm);
-            if (this._settings.get_boolean('show-voltage'))
+            if (showVolt)
                 voltageInfo = voltageInfo.concat(this._utils.freeipmi.volt);
         }
 
         if (this._utils.liquidctl && this._utils.liquidctl.available) {
-            if (this._settings.get_boolean('show-temperature'))
+            if (showTemp)
                 sensorsTempInfo = sensorsTempInfo.concat(this._utils.liquidctl.temp);
-            if (this._settings.get_boolean('show-rotationrate'))
+            if (showRpm)
                 fanInfo = fanInfo.concat(this._utils.liquidctl.rpm);
-            if (this._settings.get_boolean('show-voltage'))
+            if (showVolt)
                 voltageInfo = voltageInfo.concat(this._utils.liquidctl.volt);
         }
 
         if (this._utils.battery && this._utils.battery.available) {
-            if (this._settings.get_boolean('show-battery-stats')) {
+            if (showBattery) {
                 powerInfo = powerInfo.concat(this._utils.battery.power)
             }
         }
 
-        if (this._utils.nvidia && this._utils.nvidia.available)
-            if (this._settings.get_boolean('show-temperature'))
+        if (showTemp) {
+            if (this._utils.nvidia && this._utils.nvidia.available)
                 gpuTempInfo = gpuTempInfo.concat(this._utils.nvidia.temp);
 
-        if (this._utils.nvidiabumblebee && this._utils.nvidiabumblebee.available)
-            if (this._settings.get_boolean('show-temperature'))
+            if (this._utils.nvidiabumblebee && this._utils.nvidiabumblebee.available)
                 gpuTempInfo = gpuTempInfo.concat(this._utils.nvidiabumblebee.temp);
 
-        if (this._utils.aticonfig && this._utils.aticonfig.available)
-            if (this._settings.get_boolean('show-temperature'))
+            if (this._utils.aticonfig && this._utils.aticonfig.available)
                 gpuTempInfo = gpuTempInfo.concat(this._utils.aticonfig.temp);
 
-        if (this._utils.udisks2 && this._utils.udisks2.available)
-            if (this._settings.get_boolean('show-temperature'))
+            if (this._utils.udisks2 && this._utils.udisks2.available)
                 driveTempInfo = driveTempInfo.concat(this._utils.udisks2.temp);
 
-        if (this._utils.hddtemp && this._utils.hddtemp.available)
-            if (this._settings.get_boolean('show-temperature'))
+            if (this._utils.hddtemp && this._utils.hddtemp.available)
                 driveTempInfo = driveTempInfo.concat(this._utils.hddtemp.temp);
 
-        if (this._utils.smartctl && this._utils.smartctl.available)
-            if (this._settings.get_boolean('show-temperature'))
+            if (this._utils.smartctl && this._utils.smartctl.available)
                 driveTempInfo = driveTempInfo.concat(this._utils.smartctl.temp);
 
-        if (this._utils.nvmecli && this._utils.nvmecli.available)
-            if (this._settings.get_boolean('show-temperature'))
+            if (this._utils.nvmecli && this._utils.nvmecli.available)
                 driveTempInfo = driveTempInfo.concat(this._utils.nvmecli.temp);
+        }
 
         const comparator = (a, b) => a.label.localeCompare(b.label, undefined, {numeric: true})
         sensorsTempInfo.sort(comparator);

--- a/freon@UshakovVasilii_Github.yahoo.com/extension.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/extension.js
@@ -177,6 +177,7 @@ class FreonMenuButton extends PanelMenu.Button {
         });
         this._positionInPanelChangedTimeoutId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 500, () => {
             this._positionInPanelChanged();
+            this._positionInPanelChangedTimeoutId = 0;
             return false; // execute only once
         });
     }
@@ -533,7 +534,8 @@ class FreonMenuButton extends PanelMenu.Button {
 
         GLib.Source.remove(this._timeoutId);
         GLib.Source.remove(this._updateUITimeoutId);
-        GLib.Source.remove(this._positionInPanelChangedTimeoutId);
+        if (this._positionInPanelChangedTimeoutId)
+            GLib.Source.remove(this._positionInPanelChangedTimeoutId);
 
         for (let signal of this._settingChangedSignals){
             this._settings.disconnect(signal);

--- a/freon@UshakovVasilii_Github.yahoo.com/extension.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/extension.js
@@ -145,7 +145,7 @@ class FreonMenuButton extends PanelMenu.Button {
         this._addSettingChangedSignal('show-battery-stats', this._batteryUtilityChanged.bind(this));
 
         this._addSettingChangedSignal('use-gpu-nvidia', this._nvidiaUtilityChanged.bind(this));
-        this._addSettingChangedSignal('use-gpu-nvidiabumblebee', this._nvidiabumblebeeUtilityChanged.bind(this));
+        this._addSettingChangedSignal('use-gpu-bumblebeenvidia', this._nvidiabumblebeeUtilityChanged.bind(this));
         this._addSettingChangedSignal('use-gpu-aticonfig', this._aticonfigUtilityChanged.bind(this));
 
         this._addSettingChangedSignal('use-drive-udisks2', this._udisks2UtilityChanged.bind(this));

--- a/freon@UshakovVasilii_Github.yahoo.com/freeipmiUtil.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/freeipmiUtil.js
@@ -5,7 +5,7 @@ import PkexecUtil from './pkexecUtil.js';
 
 export default class FreeipmiUtil extends CommandLineUtil {
 
-    constructor(exec_method) {
+    constructor(exec_method, extensionDir) {
         super();
 
         const path = GLib.find_program_in_path('ipmi-sensors');
@@ -14,19 +14,24 @@ export default class FreeipmiUtil extends CommandLineUtil {
 
         if (this._argv && exec_method === 'pkexec')
         {
-            let pkexecUtil = new PkexecUtil('ipmi-sensors');
+            let pkexecUtil = new PkexecUtil('ipmi-sensors', extensionDir);
             if (!pkexecUtil.checkOrInstall()) {
-                throw 'cannot run ipmi-sensors with pkexec';
+                throw new Error('cannot run ipmi-sensors with pkexec');
             }
             const pkexec_path = GLib.find_program_in_path('pkexec');
             this._argv = pkexec_path ? [pkexec_path].concat(this._argv) : null;
         }
     }
 
+    destroy() {
+        super.destroy();
+        this._data = null;
+    }
+
     // Avoid parsing the data more than once.
     execute(callback) {
         super.execute(() => {
-            let data = [];
+            const data = Object.create(null);
 
             for (const line of this._output) {
                 if (!line)
@@ -35,7 +40,7 @@ export default class FreeipmiUtil extends CommandLineUtil {
                 const value_list = line.split(',');
 
                 if (value_list.length <= 1)
-                    break;
+                    continue;
 
                 const id = value_list[0];
 
@@ -47,9 +52,7 @@ export default class FreeipmiUtil extends CommandLineUtil {
                 const unit = value_list[4];
 
                 if (value !== 'N/A' && unit !== 'N/A') {
-                    data[name] = {};
-                    data[name]["value"] = value;
-                    data[name]["unit"] = unit;
+                    data[name] = { value: value, unit: unit };
                 }
             }
 
@@ -70,31 +73,26 @@ export default class FreeipmiUtil extends CommandLineUtil {
         return this._parseSensorsOutput(/^V$/, 'volt');
     }
 
-  _parseSensorsOutput(sensorFilter, sensorType) {
-        if(!this._data)
+    _parseSensorsOutput(sensorFilter, sensorType) {
+        if (!this._data)
             return [];
 
         const data = this._data;
 
         let sensors = [];
         for (const name in data) {
-            if (!data.hasOwnProperty(name))
-                continue;
-
-            const value = data[name]["value"]
-            const unit = data[name]["unit"]
+            const value = data[name]["value"];
+            const unit = data[name]["unit"];
 
             if (!sensorFilter.test(unit))
                 continue;
 
-            const feature = {
+            sensors.push({
                 label: name,
                 [sensorType]: parseFloat(value)
-            };
-
-            sensors.push(feature);
+            });
         }
 
         return sensors;
     }
-};
+}

--- a/freon@UshakovVasilii_Github.yahoo.com/freonItem.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/freonItem.js
@@ -17,10 +17,10 @@ export default class FreonItem extends PopupMenu.PopupBaseMenuItem {
         this._gIcon = gIcon;
 
         this._labelActor = new St.Label({text: displayName ? displayName : label, x_align: Clutter.ActorAlign.CENTER, x_expand: true});
-        this.actor.add_child(new St.Icon({ style_class: 'popup-menu-icon', gicon : gIcon}));
-        this.actor.add_child(this._labelActor);
+        this.add_child(new St.Icon({ style_class: 'popup-menu-icon', gicon : gIcon}));
+        this.add_child(this._labelActor);
         this._valueLabel = new St.Label({text: value});
-        this.actor.add_child(this._valueLabel);
+        this.add_child(this._valueLabel);
     }
 
     set main(main) {
@@ -40,7 +40,7 @@ export default class FreonItem extends PopupMenu.PopupBaseMenuItem {
     }
 
     set display_name(text) {
-        return this._labelActor.text = text;
+        this._labelActor.text = text;
     }
 
     get gicon() {

--- a/freon@UshakovVasilii_Github.yahoo.com/hddtempUtil.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/hddtempUtil.js
@@ -45,7 +45,8 @@ export default class HddtempUtil extends CommandLineUtil {
 
         if(nc && pid) {
             // get daemon command line
-            let cmdline = GLib.file_get_contents('/proc/'+pid+'/cmdline');
+            let [, cmdlineBytes] = GLib.file_get_contents('/proc/'+pid+'/cmdline');
+            let cmdline = new TextDecoder().decode(cmdlineBytes);
             // get port or assume default
             let match = /(-p\W*|--port=)(\d{1,5})/.exec(cmdline)
             let port = match ? parseInt(match[2]) : 7634;

--- a/freon@UshakovVasilii_Github.yahoo.com/hddtempUtil.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/hddtempUtil.js
@@ -1,76 +1,132 @@
+import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
 
 import CommandLineUtil from './commandLineUtil.js';
 
-function run_command(argv) {
-    return new TextDecoder().decode(GLib.spawn_command_line_sync(argv)[1]).trim();
+function spawnAsync(argv, cancellable, cb) {
+    let proc;
+    try {
+        proc = Gio.Subprocess.new(argv,
+            Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_PIPE);
+    } catch (e) {
+        cb({ ok: false, status: -1, stdout: '' });
+        return;
+    }
+    proc.communicate_utf8_async(null, cancellable, (p, res) => {
+        try {
+            let [, stdout] = p.communicate_utf8_finish(res);
+            cb({ ok: proc.get_successful(), status: proc.get_exit_status(), stdout: stdout || '' });
+        } catch (e) {
+            if (!e.matches?.(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED))
+                logError(e, '[FREON] hddtemp probe failed');
+            cb({ ok: false, status: -1, stdout: '' });
+        }
+    });
 }
 
 export default class HddtempUtil extends CommandLineUtil {
 
     constructor() {
         super();
-        let hddtempArgv = GLib.find_program_in_path('hddtemp');
-        if(hddtempArgv) {
+        this._sep = ': ';
+        this._probe();
+    }
+
+    _probe() {
+        const hddtempPath = GLib.find_program_in_path('hddtemp');
+        if (hddtempPath) {
             // check if this user can run hddtemp directly.
-            if(!GLib.spawn_command_line_sync(hddtempArgv)[3]){
-                this._argv = [hddtempArgv];
-                return;
-            }
+            spawnAsync([hddtempPath], this._cancellable, (res) => {
+                if (this._destroyed) return;
+                if (res.status === 0) {
+                    this._argv = [hddtempPath];
+                    this._sep = ': ';
+                    return;
+                }
+                this._probeDaemon();
+            });
+        } else {
+            this._probeDaemon();
         }
+    }
 
+    _probeDaemon() {
         // doesn't seem to be the case… is it running as a daemon?
-        // Check first for systemd
-        let systemctl = GLib.find_program_in_path('systemctl');
-        let pidof = GLib.find_program_in_path('pidof');
-        let nc = GLib.find_program_in_path('nc');
-        let pid = undefined;
+        const systemctl = GLib.find_program_in_path('systemctl');
+        const pidof = GLib.find_program_in_path('pidof');
+        const nc = GLib.find_program_in_path('nc');
+        if (!nc) return;
 
-        if(systemctl) {
-            let activeState = run_command(systemctl + " show hddtemp.service -p ActiveState");
-            if(activeState == "ActiveState=active") {
-                let output = run_command(systemctl + " show hddtemp.service -p MainPID");
-
-                if(output.length && output.split("=").length == 2)
-                    pid = Number(output.split("=")[1].trim());
-            }
-        }
-
-        // systemd isn't used on this system, try sysvinit instead
-        if(!pid && pidof) {
-            let output = run_command("pidof hddtemp");
-            if(output.length)
-                pid = Number(output.trim());
-        }
-
-        if(nc && pid) {
+        const finalize = (pid) => {
+            if (this._destroyed || !pid) return;
             // get daemon command line
-            let [, cmdlineBytes] = GLib.file_get_contents('/proc/'+pid+'/cmdline');
-            let cmdline = new TextDecoder().decode(cmdlineBytes);
-            // get port or assume default
-            let match = /(-p\W*|--port=)(\d{1,5})/.exec(cmdline)
-            let port = match ? parseInt(match[2]) : 7634;
-            // use net cat to get data
+            let port = 7634;
+            try {
+                let [ok, cmdlineBytes] = GLib.file_get_contents('/proc/' + pid + '/cmdline');
+                if (ok) {
+                    let cmdline = new TextDecoder().decode(cmdlineBytes);
+                    let match = /(-p\W*|--port=)(\d{1,5})/.exec(cmdline);
+                    if (match) port = parseInt(match[2]);
+                }
+            } catch (e) {
+                // ignore; use default port
+            }
             this._argv = [nc, 'localhost', port.toString()];
+            this._sep = '|';
+        };
+
+        if (systemctl) {
+            spawnAsync([systemctl, 'show', 'hddtemp.service', '-p', 'ActiveState'], this._cancellable, (res) => {
+                if (this._destroyed) return;
+                if (res.stdout.trim() === 'ActiveState=active') {
+                    spawnAsync([systemctl, 'show', 'hddtemp.service', '-p', 'MainPID'], this._cancellable, (res2) => {
+                        if (this._destroyed) return;
+                        let parts = res2.stdout.trim().split('=');
+                        let pid = parts.length === 2 ? Number(parts[1]) : 0;
+                        if (pid) {
+                            finalize(pid);
+                        } else if (pidof) {
+                            spawnAsync([pidof, 'hddtemp'], this._cancellable, (r) => {
+                                if (this._destroyed) return;
+                                let p = Number(r.stdout.trim());
+                                if (p) finalize(p);
+                            });
+                        }
+                    });
+                } else if (pidof) {
+                    spawnAsync([pidof, 'hddtemp'], this._cancellable, (r) => {
+                        if (this._destroyed) return;
+                        let p = Number(r.stdout.trim());
+                        if (p) finalize(p);
+                    });
+                }
+            });
+        } else if (pidof) {
+            spawnAsync([pidof, 'hddtemp'], this._cancellable, (r) => {
+                if (this._destroyed) return;
+                let p = Number(r.stdout.trim());
+                if (p) finalize(p);
+            });
         }
     }
 
     get temp() {
-        if(!this._output)
+        if (!this._output)
             return [];
 
-        let sep = /nc$/.exec(this._argv[0]) ? '|' : ': ';
+        const sep = this._sep;
         let hddtempOutput = [];
-        if (this._output.join().indexOf(sep+sep) > 0) {
-            hddtempOutput = this._output.join().split(sep+sep);
+        if (this._output.join().indexOf(sep + sep) > 0) {
+            hddtempOutput = this._output.join().split(sep + sep);
         } else {
             hddtempOutput = this._output;
         }
 
         let sensors = [];
         for (let line of hddtempOutput) {
-            let fields = line.split(sep).filter(function(e){ return e; });
-            let sensor = { label: fields[1], temp: parseFloat(fields[2])};
+            let fields = line.split(sep).filter(function(e) { return e; });
+            if (fields.length < 3) continue;
+            let sensor = { label: fields[1], temp: parseFloat(fields[2]) };
             //push only if the temp is a Number
             if (!isNaN(sensor.temp))
                 sensors.push(sensor);
@@ -79,4 +135,4 @@ export default class HddtempUtil extends CommandLineUtil {
         return sensors;
     }
 
-};
+}

--- a/freon@UshakovVasilii_Github.yahoo.com/liquidctlUtil.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/liquidctlUtil.js
@@ -86,4 +86,4 @@ export default class LiquidctlUtil extends CommandLineUtil {
     get volt() {
         return this._volt || [];
     }
-};
+}

--- a/freon@UshakovVasilii_Github.yahoo.com/nvidiaUtil.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/nvidiaUtil.js
@@ -8,9 +8,15 @@ export default class NvidiaUtil {
         this._updated = false;
         this._gpuInfo = {};
         this._output = [];
+        this._cancellable = new Gio.Cancellable();
+        this._destroyed = false;
     }
 
     async execute(callback) {
+        if (this._destroyed) {
+            if (callback) callback();
+            return;
+        }
         try {
             // Read all GPUs from /proc/driver/nvidia/gpus.
             const directory = Gio.File.new_for_path('/proc/driver/nvidia/gpus');
@@ -19,7 +25,7 @@ export default class NvidiaUtil {
                     'standard::*',
                     Gio.FileQueryInfoFlags.NOFOLLOW_SYMLINKS,
                     GLib.PRIORITY_DEFAULT,
-                    null,
+                    this._cancellable,
                     (file_, result) => {
                         try {
                             resolve(directory.enumerate_children_finish(result));
@@ -29,11 +35,13 @@ export default class NvidiaUtil {
                     }
                 );
             });
-            const gpus = []
-    
+            if (this._destroyed) return;
+            const gpus = [];
+
             while (true) {
+                if (this._destroyed) return;
                 const infos = await new Promise((resolve, reject) => {
-                    iter.next_files_async(10, GLib.PRIORITY_DEFAULT, null, (iter_, res) => {
+                    iter.next_files_async(10, GLib.PRIORITY_DEFAULT, this._cancellable, (iter_, res) => {
                         try {
                             resolve(iter.next_files_finish(res));
                         } catch (e) {
@@ -41,21 +49,22 @@ export default class NvidiaUtil {
                         }
                     });
                 });
-    
+
                 if (infos.length === 0)
                     break;
-    
+
                 for (const info of infos)
                     gpus.push(info.get_name());
             }
-    
+
             // For each GPU...
             let gpuInfo = {};
             for (const gpu of gpus) {
+                if (this._destroyed) return;
                 // ...read /proc/driver/nvidia/gpus/<ID>/power and check if it supports sleep.
                 const file = Gio.File.new_for_path(`/proc/driver/nvidia/gpus/${gpu}/power`);
                 const [, contents, etag] = await new Promise((resolve, reject) => {
-                    file.load_contents_async(null, (file_, result) => {
+                    file.load_contents_async(this._cancellable, (file_, result) => {
                         try {
                             resolve(file.load_contents_finish(result));
                         } catch (e) {
@@ -63,7 +72,8 @@ export default class NvidiaUtil {
                         }
                     });
                 });
-    
+                if (this._destroyed) return;
+
                 // If the GPU is sleeping, don't poll it.
                 const decoder = new TextDecoder('utf-8');
                 const contentsString = decoder.decode(contents);
@@ -79,31 +89,38 @@ export default class NvidiaUtil {
                     gpuInfo[gpu] = prevGpuInfo;
                     continue;
                 }
-                
+
                 // Poll the GPU.
                 gpuInfo[gpu] = { output: await this.getGpuInfo(gpu) };
-                
+                if (this._destroyed) return;
+
                 // If runtime D3 is enabled and the GPU is eligible to sleep...
                 try {
                     const sleepEligible = await this.isGpuEligibleToSleep(gpu);
+                    if (this._destroyed) return;
                     if (contentsString.split('\n')[0].includes('Enabled') && sleepEligible) {
                         // ...skip polling it for 30 seconds.
                         gpuInfo[gpu].skipUntil = Date.now() + 30000;
                     }
                 } catch (e) {
-                    console.error(e);
+                    if (!e.matches?.(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED))
+                        console.error(e);
                 }
             }
+            if (this._destroyed) return;
             this._gpuInfo = gpuInfo;
             this._output = Object.keys(this._gpuInfo)
                 .sort()
                 .map(gpu => gpuInfo[gpu].output)
                 .filter(output => !!output);
         } catch (e) {
-            console.error(e);
+            if (!e.matches?.(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED))
+                console.error(e);
         } finally {
-            callback();
-            this._updated = true;
+            if (!this._destroyed) {
+                this._updated = true;
+                if (callback) callback();
+            }
         }
     }
 
@@ -114,7 +131,7 @@ export default class NvidiaUtil {
                 Gio.SubprocessFlags.STDOUT_PIPE |
                 Gio.SubprocessFlags.STDERR_PIPE);
 
-            proc.communicate_utf8_async(null, null, (proc, result) => {
+            proc.communicate_utf8_async(null, this._cancellable, (proc, result) => {
                 try {
                     let [, stdout, stderr] = proc.communicate_utf8_finish(result);
                     const processes = stdout ? stdout.trim().split('\n').slice(2) : [];
@@ -139,7 +156,7 @@ export default class NvidiaUtil {
                 Gio.SubprocessFlags.STDOUT_PIPE |
                 Gio.SubprocessFlags.STDERR_PIPE);
 
-            proc.communicate_utf8_async(null, null, (proc, result) => {
+            proc.communicate_utf8_async(null, this._cancellable, (proc, result) => {
                 try {
                     let [, stdout, stderr] = proc.communicate_utf8_finish(result);
                     resolve(stdout ? stdout.trim() : '');
@@ -184,8 +201,13 @@ export default class NvidiaUtil {
         this._updated = updated;
     }
 
-    destroy(callback) {
+    destroy() {
+        this._destroyed = true;
+        if (this._cancellable) {
+            this._cancellable.cancel();
+            this._cancellable = null;
+        }
         this._gpuInfo = {};
         this._output = [];
     }
-};
+}

--- a/freon@UshakovVasilii_Github.yahoo.com/nvmecliUtil.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/nvmecliUtil.js
@@ -1,16 +1,49 @@
+import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
 
-function getNvmeData (argv){
-    const nvme = GLib.find_program_in_path('nvme')
-    return JSON.parse(new TextDecoder().decode(GLib.spawn_command_line_sync(`${nvme} ${argv} -o json`)[1]))
+const NVME = GLib.find_program_in_path('nvme');
+
+function spawnJsonSync(args) {
+    if (!NVME)
+        return null;
+    let proc = Gio.Subprocess.new([NVME, ...args, '-o', 'json'],
+        Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_PIPE);
+    let [, stdout] = proc.communicate_utf8(null, null);
+    return JSON.parse(stdout);
+}
+
+function spawnJsonAsync(args, cb) {
+    if (!NVME) {
+        cb(null);
+        return;
+    }
+    let proc;
+    try {
+        proc = Gio.Subprocess.new([NVME, ...args, '-o', 'json'],
+            Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_PIPE);
+    } catch (e) {
+        logError(e, '[FREON] nvme spawn failed');
+        cb(null);
+        return;
+    }
+    proc.communicate_utf8_async(null, null, (p, res) => {
+        try {
+            let [, stdout] = p.communicate_utf8_finish(res);
+            cb(JSON.parse(stdout));
+        } catch (e) {
+            logError(e, '[FREON] nvme parse failed');
+            cb(null);
+        }
+    });
 }
 
 export default class NvmecliUtil {
 
     constructor(callback) {
         this._nvmeDevices = [];
+        this._sensors = [];
         try {
-            this._nvmeDevices = getNvmeData("list")["Devices"]
+            this._nvmeDevices = spawnJsonSync(["list"])["Devices"];
         } catch (e) {
             logError(e, '[FREON] Unable to find nvme devices');
         }
@@ -30,29 +63,53 @@ export default class NvmecliUtil {
     }
 
     get temp() {
-        let sensors = [];
-        for (let device of this._nvmeDevices) {
-            var smart_log = getNvmeData(`smart-log ${device["DevicePath"]}`);
-            if( smart_log.hasOwnProperty('temperature_sensor_2') ){
-                sensors.push({ label: device["ModelNumber"] + " S1",
-                               temp: parseFloat(smart_log.temperature_sensor_1) - 273.15 });
-                sensors.push({ label: device["ModelNumber"] + " S2",
-                               temp: parseFloat(smart_log.temperature_sensor_2) - 273.15 });
-                }
-            else{
-                 sensors.push({ label: device["ModelNumber"],
-                                temp: parseFloat(smart_log.temperature) - 273.15 });
-            }
-       }
-       return sensors;
-   }
+        return this._sensors;
+    }
 
     destroy(callback) {
         this._nvmeDevices = [];
+        this._sensors = [];
     }
 
     execute(callback) {
-        this._updated = true;
+        if (this._nvmeDevices.length === 0) {
+            this._updated = true;
+            if (callback) callback();
+            return;
+        }
+
+        let pending = this._nvmeDevices.length;
+        let results = [];
+        const finishOne = (entries) => {
+            if (entries) results.push(...entries);
+            if (--pending === 0) {
+                this._sensors = results;
+                this._updated = true;
+                if (callback) callback();
+            }
+        };
+
+        for (let device of this._nvmeDevices) {
+            spawnJsonAsync(["smart-log", device.DevicePath], (log) => {
+                if (!log) {
+                    finishOne(null);
+                    return;
+                }
+                if (log.hasOwnProperty('temperature_sensor_2')) {
+                    finishOne([
+                        { label: device.ModelNumber + " S1",
+                          temp: parseFloat(log.temperature_sensor_1) - 273.15 },
+                        { label: device.ModelNumber + " S2",
+                          temp: parseFloat(log.temperature_sensor_2) - 273.15 }
+                    ]);
+                } else {
+                    finishOne([{
+                        label: device.ModelNumber,
+                        temp: parseFloat(log.temperature) - 273.15
+                    }]);
+                }
+            });
+        }
     }
 
 };

--- a/freon@UshakovVasilii_Github.yahoo.com/nvmecliUtil.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/nvmecliUtil.js
@@ -3,16 +3,7 @@ import GLib from 'gi://GLib';
 
 const NVME = GLib.find_program_in_path('nvme');
 
-function spawnJsonSync(args) {
-    if (!NVME)
-        return null;
-    let proc = Gio.Subprocess.new([NVME, ...args, '-o', 'json'],
-        Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_PIPE);
-    let [, stdout] = proc.communicate_utf8(null, null);
-    return JSON.parse(stdout);
-}
-
-function spawnJsonAsync(args, cb) {
+function spawnJsonAsync(args, cancellable, cb) {
     if (!NVME) {
         cb(null);
         return;
@@ -26,12 +17,13 @@ function spawnJsonAsync(args, cb) {
         cb(null);
         return;
     }
-    proc.communicate_utf8_async(null, null, (p, res) => {
+    proc.communicate_utf8_async(null, cancellable, (p, res) => {
         try {
             let [, stdout] = p.communicate_utf8_finish(res);
             cb(JSON.parse(stdout));
         } catch (e) {
-            logError(e, '[FREON] nvme parse failed');
+            if (!e.matches?.(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED))
+                logError(e, '[FREON] nvme parse failed');
             cb(null);
         }
     });
@@ -42,12 +34,20 @@ export default class NvmecliUtil {
     constructor(callback) {
         this._nvmeDevices = [];
         this._sensors = [];
-        try {
-            this._nvmeDevices = spawnJsonSync(["list"])["Devices"];
-        } catch (e) {
-            logError(e, '[FREON] Unable to find nvme devices');
-        }
         this._updated = true;
+        this._destroyed = false;
+        this._gen = 0;
+        this._cancellable = new Gio.Cancellable();
+
+        if (NVME) {
+            spawnJsonAsync(["list"], this._cancellable, (data) => {
+                if (this._destroyed) return;
+                if (data && data.Devices)
+                    this._nvmeDevices = data.Devices;
+                this._updated = true;
+                if (callback) callback();
+            });
+        }
     }
 
     get available(){
@@ -67,30 +67,39 @@ export default class NvmecliUtil {
     }
 
     destroy(callback) {
+        this._destroyed = true;
+        if (this._cancellable) {
+            this._cancellable.cancel();
+            this._cancellable = null;
+        }
         this._nvmeDevices = [];
         this._sensors = [];
     }
 
     execute(callback) {
-        if (this._nvmeDevices.length === 0) {
+        if (this._destroyed || this._nvmeDevices.length === 0) {
             this._updated = true;
             if (callback) callback();
             return;
         }
 
+        const gen = ++this._gen;
         let pending = this._nvmeDevices.length;
         let results = [];
         const finishOne = (entries) => {
             if (entries) results.push(...entries);
             if (--pending === 0) {
-                this._sensors = results;
+                if (this._destroyed) return;
+                if (gen === this._gen)
+                    this._sensors = results;
                 this._updated = true;
                 if (callback) callback();
             }
         };
 
         for (let device of this._nvmeDevices) {
-            spawnJsonAsync(["smart-log", device.DevicePath], (log) => {
+            spawnJsonAsync(["smart-log", device.DevicePath], this._cancellable, (log) => {
+                if (this._destroyed) { finishOne(null); return; }
                 if (!log) {
                     finishOne(null);
                     return;
@@ -112,4 +121,4 @@ export default class NvmecliUtil {
         }
     }
 
-};
+}

--- a/freon@UshakovVasilii_Github.yahoo.com/pkexecUtil.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/pkexecUtil.js
@@ -2,24 +2,14 @@ import GLib from 'gi://GLib';
 import Gio from 'gi://Gio';
 
 export default class PkexecUtil {
-    constructor(name) {
+    constructor(name, extensionDir) {
         this._name = name;
         this._policy = 'com.github.UshakovVasilii.freon.' + name + '.policy';
-        this._actions = '/usr/share/polkit-1/actions'
+        this._actions = '/usr/share/polkit-1/actions';
         this._pkexec = GLib.find_program_in_path('pkexec');
         // Currently hardcoded in policy file.
         this._bin = '/usr/sbin/' + name;
-        this._dir = this.dir();
-    }
-
-    dir() {
-        let uri = (new Error()).stack.split('\n')[1];
-        let prefix = this.constructor.name + '@file://'
-        if (!uri.startsWith(prefix)) {
-            log('[FREON] failed to guess extension directory');
-            return null;
-        }
-        return Gio.File.new_for_path(uri.substring(prefix.length)).get_parent().get_path();
+        this._dir = extensionDir || null;
     }
 
     available_pkexec() {
@@ -34,21 +24,26 @@ export default class PkexecUtil {
         return GLib.file_test(this._actions + '/' + this._policy, GLib.FileTest.EXISTS);
     }
 
-    run(command) {
-        return GLib.spawn_command_line_sync(this._pkexec + ' ' + command);
-    }
-
     install() {
-        if (!this._dir)
-        {
+        if (!this._dir) {
             log('[FREON] cannot find ' + this._name + ' pkexec policy file ' + this._policy);
             return false;
         }
+        if (!this._pkexec)
+            return false;
         try {
-            this.run('install "' + this._dir + '/policies/' + this._policy + '" ' + this._actions);
-        } catch(e) {}
-        if (!this.installed())
-        {
+            let proc = Gio.Subprocess.new(
+                [this._pkexec,
+                 'install',
+                 this._dir + '/policies/' + this._policy,
+                 this._actions],
+                Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_PIPE
+            );
+            proc.wait(null);
+        } catch (e) {
+            log('[FREON] pkexec install failed: ' + e);
+        }
+        if (!this.installed()) {
             log('[FREON] failed to install ' + this._name + ' pkexec policy');
             return false;
         }

--- a/freon@UshakovVasilii_Github.yahoo.com/prefs.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/prefs.js
@@ -69,7 +69,7 @@ export default class FreonPreferences extends ExtensionPreferences {
 
         const position_in_panel = new Adw.ComboRow({
             title: _('Panel Position'),
-            model: new Gtk.StringList({strings: ["Left", "Center", "Right"] }),
+            model: new Gtk.StringList({strings: [_("Left"), _("Center"), _("Right")] }),
         })
         this._settings.bind("position-in-panel", position_in_panel, "selected", Gio.SettingsBindFlags.NO_SENSITIVITY);
         group.add(position_in_panel)
@@ -115,9 +115,9 @@ export default class FreonPreferences extends ExtensionPreferences {
 
         const freeimpi = new Adw.ComboRow({
             title: _('FreeIMPI'),
-            model: new Gtk.StringList({strings: ["Disabled", "Direct", "pkexec"] }),
+            model: new Gtk.StringList({strings: [_("Disabled"), _("Direct"), "pkexec"] }),
             selected: this._settings.get_int("freeimpi-selected"),
-            subtitle: "Read sensors using ipmi-sensors from FreeIPMI"
+            subtitle: _("Read sensors using ipmi-sensors from FreeIPMI")
         });
         this._settings.bind("freeimpi-selected", freeimpi, "selected", Gio.SettingsBindFlags.NO_SENSITIVITY);
         group.add(freeimpi);
@@ -177,11 +177,12 @@ export default class FreonPreferences extends ExtensionPreferences {
     }
 
     _addSwitch(title, key, help = "") {
-        const sw = new Adw.SwitchRow({
+        const params = {
             title: _(title),
             active: this._settings.get_boolean(key),
-            subtitle: help
-        });
+        };
+        if (help) params.subtitle = _(help);
+        const sw = new Adw.SwitchRow(params);
         this._settings.bind(key, sw, 'active', Gio.SettingsBindFlags.DEFAULT);
         return sw;
     }

--- a/freon@UshakovVasilii_Github.yahoo.com/prefs.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/prefs.js
@@ -71,7 +71,7 @@ export default class FreonPreferences extends ExtensionPreferences {
             title: _('Panel Position'),
             model: new Gtk.StringList({strings: ["Left", "Center", "Right"] }),
         })
-        this._settings.bind("position-in-panel", position_in_panel, "selected", Gio.SettingsBindFlags.NO_SENSETIVITY);
+        this._settings.bind("position-in-panel", position_in_panel, "selected", Gio.SettingsBindFlags.NO_SENSITIVITY);
         group.add(position_in_panel)
 
         
@@ -93,7 +93,7 @@ export default class FreonPreferences extends ExtensionPreferences {
             title: _('Temperature Unit'),
             model: new Gtk.StringList({strings: ["\u00b0C", "\u00b0F"]}),
         });
-        this._settings.bind("unit", unit_setting, "selected", Gio.SettingsBindFlags.NO_SENSETIVITY);
+        this._settings.bind("unit", unit_setting, "selected", Gio.SettingsBindFlags.NO_SENSITIVITY);
         group.add(unit_setting);
 
         group.add(this._addSwitch("Show Temperature Unit", "show-temperature-unit"));
@@ -119,7 +119,7 @@ export default class FreonPreferences extends ExtensionPreferences {
             selected: this._settings.get_int("freeimpi-selected"),
             subtitle: "Read sensors using ipmi-sensors from FreeIPMI"
         });
-        this._settings.bind("freeimpi-selected", freeimpi, "selected", Gio.SettingsBindFlags.NO_SENSETIVITY);
+        this._settings.bind("freeimpi-selected", freeimpi, "selected", Gio.SettingsBindFlags.NO_SENSITIVITY);
         group.add(freeimpi);
 
         return group;

--- a/freon@UshakovVasilii_Github.yahoo.com/schemas/org.gnome.shell.extensions.sensors.gschema.xml
+++ b/freon@UshakovVasilii_Github.yahoo.com/schemas/org.gnome.shell.extensions.sensors.gschema.xml
@@ -6,11 +6,12 @@
     <key name="hot-sensors" type="as">
       <default>["__average__", "__max__"]</default>
       <summary>Sensors to show in panel</summary>
-      <description>Select the sensord whose values has to be shown in the panel</description>
+      <description>Select the sensors whose values are shown in the panel</description>
     </key>
 
     <key type="i" name="update-time">
       <default>5</default>
+      <range min="1" max="600"/>
       <summary>Seconds before next update</summary>
       <description>This is the seconds after CPU temperature extension updates the data from the system</description>
     </key>
@@ -36,7 +37,7 @@
     <key type="i" name="unit">
       <default>0</default>
       <summary>Select centigrade or fahrenheit</summary>
-      <description>Choose wether to display the Number for centigrade or fahrenheit</description>
+      <description>Choose whether to display the value in centigrade or fahrenheit</description>
     </key>
 
     <key type="b" name="show-temperature-unit">
@@ -47,8 +48,8 @@
 
     <key type="b" name="show-temperature">
       <default>true</default>
-      <summary>Show RPM on Panel</summary>
-      <description>Show RPM on Panel</description>
+      <summary>Display Temperature</summary>
+      <description>Display temperature sensors</description>
     </key>
 
     <key type="b" name="show-rotationrate-unit">
@@ -91,12 +92,6 @@
       <default>0</default>
       <summary>Selected element number in the FreeIMPI-Dropdown</summary>
       <description>Selected element number in the FreeIMPI-Dropdown</description>
-    </key>
-
-    <key type="s" name="exec-method-freeipmi">
-      <default>'Disabled'</default>
-      <summary>Method to run FreeIPMI utility</summary>
-      <description>Method to run FreeIPMI utility</description>
     </key>
 
     <key type="b" name="use-generic-liquidctl">

--- a/freon@UshakovVasilii_Github.yahoo.com/sensorsUtil.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/sensorsUtil.js
@@ -2,6 +2,22 @@ import GLib from 'gi://GLib';
 
 import CommandLineUtil from './commandLineUtil.js';
 
+const TEMP_RE = /^temp\d+_input/;
+const FAN_RE = /^fan\d+_input/;
+const VOLT_RE = /^in\d+_input/;
+const POWER_RE = /^power\d+_average/;
+const GPU_CHIPSET_RE = /(radeon|amdgpu|nouveau)/;
+const DISK_CHIPSET_RE = /(drivetemp|nvme)/;
+
+const EMPTY_GROUPS = Object.freeze({
+    temp: [],
+    gpu: [],
+    disks: [],
+    rpm: [],
+    volt: [],
+    power: [],
+});
+
 export default class SensorsUtil extends CommandLineUtil {
 
     constructor() {
@@ -9,12 +25,12 @@ export default class SensorsUtil extends CommandLineUtil {
         let path = GLib.find_program_in_path('sensors');
         // -A: Do not show adapter -j: JSON output
         this._argv = path ? [path, '-A', '-j'] : null;
+        this._groups = EMPTY_GROUPS;
     }
 
-    // Avoid parsing the data more than once.
     execute(callback) {
         super.execute(() => {
-            let data = [];
+            let data = null;
             try {
                 data = JSON.parse(this._output.join(''));
             } catch (e) {
@@ -23,83 +39,72 @@ export default class SensorsUtil extends CommandLineUtil {
                     // https://github.com/UshakovVasilii/gnome-shell-extension-freon/issues/114#issuecomment-491613545
                     let lineRemoved = this._output.filter(l => l.trim() !== ',').join('\n');
                     let errorRemoved = lineRemoved.replace(/ERROR.*Can't read/, "");
-                        errorRemoved = errorRemoved.replace(/ERROR.*I\/O error/, "");
-                        errorRemoved = errorRemoved.replace(/NaN/, "0");
-                        data = JSON.parse(errorRemoved);
-                } catch (e) {
-                    logError(e);
-                    return [];
+                    errorRemoved = errorRemoved.replace(/ERROR.*I\/O error/, "");
+                    errorRemoved = errorRemoved.replace(/NaN/, "0");
+                    data = JSON.parse(errorRemoved);
+                } catch (e2) {
+                    logError(e2);
+                    this._groups = EMPTY_GROUPS;
+                    callback();
+                    return;
                 }
             }
-            this._data = data;
+            this._groups = this._buildGroups(data);
             callback();
         });
     }
 
-    get temp() {
-        return this._parseSensorsOutput(/^temp\d+_input/, 'temp', 'generic');
-    }
+    _buildGroups(data) {
+        const groups = { temp: [], gpu: [], disks: [], rpm: [], volt: [], power: [] };
 
-    get gpu() {
-        return this._parseSensorsOutput(/^temp\d+_input/, 'temp', 'gpu');
-    }
-
-    get disks() {
-        return this._parseSensorsOutput(/^temp\d+_input/, 'temp', 'disk');
-    }
-
-    get rpm() {
-        return this._parseSensorsOutput(/^fan\d+_input/, 'rpm', 'generic');
-    }
-
-    get volt() {
-        return this._parseSensorsOutput(/^in\d+_input/, 'volt', 'generic');
-    }
-
-    get power() {
-        return this._parseSensorsOutput(/^power\d+_average/, 'power', 'gpu');
-    }
-
-  _parseSensorsOutput(sensorFilter, sensorType, sensorFamily) {
-        if(!this._data)
-            return [];
-
-        const data = this._data;
-
-        let sensors = [];
-        for (var chipset in data) {
-            let tempType = (sensorType === 'temp')
-            let powerType = (sensorType === 'power')
-
-            let gpuFilter = /(radeon|amdgpu|nouveau)/;
-            let gpuFamily = (sensorFamily === 'gpu')
-
-            if (!data.hasOwnProperty(chipset) || (gpuFamily != gpuFilter.test(chipset) && (tempType || powerType)))
+        for (const chipset in data) {
+            if (!data.hasOwnProperty(chipset))
                 continue;
 
-            let diskFilter = /(drivetemp|nvme)/;
-            let diskFamily = (sensorFamily === 'disk')
-            if (!data.hasOwnProperty(chipset) || (diskFamily != diskFilter.test(chipset) && tempType))
-                continue;
+            const isGpu = GPU_CHIPSET_RE.test(chipset);
+            const isDisk = DISK_CHIPSET_RE.test(chipset);
+            const chipsetSensors = data[chipset];
 
-            let chipsetSensors = data[chipset]
-            for (var sensor in chipsetSensors) {
+            for (const sensor in chipsetSensors) {
                 if (!chipsetSensors.hasOwnProperty(sensor))
                     continue;
 
-                let fields = chipsetSensors[sensor];
-                for (var key in fields) {
-                    if (fields.hasOwnProperty(key) && sensorFilter.test(key)) {
-                        let feature = {
-                            label: sensor,
-                            [sensorType]: parseFloat(fields[key])
-                        };
-                        sensors.push(feature);
+                const fields = chipsetSensors[sensor];
+
+                for (const key in fields) {
+                    if (!fields.hasOwnProperty(key))
+                        continue;
+
+                    if (TEMP_RE.test(key)) {
+                        const entry = { label: sensor, temp: parseFloat(fields[key]) };
+                        if (isGpu) groups.gpu.push(entry);
+                        else if (isDisk) groups.disks.push(entry);
+                        else groups.temp.push(entry);
+                        break;
+                    }
+                    if (FAN_RE.test(key)) {
+                        groups.rpm.push({ label: sensor, rpm: parseFloat(fields[key]) });
+                        break;
+                    }
+                    if (VOLT_RE.test(key)) {
+                        groups.volt.push({ label: sensor, volt: parseFloat(fields[key]) });
+                        break;
+                    }
+                    if (POWER_RE.test(key) && isGpu) {
+                        groups.power.push({ label: sensor, power: parseFloat(fields[key]) });
                         break;
                     }
                 }
             }
         }
-        return sensors;
+
+        return groups;
     }
+
+    get temp()  { return this._groups.temp; }
+    get gpu()   { return this._groups.gpu; }
+    get disks() { return this._groups.disks; }
+    get rpm()   { return this._groups.rpm; }
+    get volt()  { return this._groups.volt; }
+    get power() { return this._groups.power; }
 };

--- a/freon@UshakovVasilii_Github.yahoo.com/sensorsUtil.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/sensorsUtil.js
@@ -40,7 +40,7 @@ export default class SensorsUtil extends CommandLineUtil {
                     let lineRemoved = this._output.filter(l => l.trim() !== ',').join('\n');
                     let errorRemoved = lineRemoved.replace(/ERROR.*Can't read/, "");
                     errorRemoved = errorRemoved.replace(/ERROR.*I\/O error/, "");
-                    errorRemoved = errorRemoved.replace(/NaN/, "0");
+                    errorRemoved = errorRemoved.replace(/NaN/g, "0");
                     data = JSON.parse(errorRemoved);
                 } catch (e2) {
                     logError(e2);
@@ -107,4 +107,4 @@ export default class SensorsUtil extends CommandLineUtil {
     get rpm()   { return this._groups.rpm; }
     get volt()  { return this._groups.volt; }
     get power() { return this._groups.power; }
-};
+}

--- a/freon@UshakovVasilii_Github.yahoo.com/smartctlUtil.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/smartctlUtil.js
@@ -1,16 +1,49 @@
+import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
 
-function getSmartData (argv){
-    const smartctl = GLib.find_program_in_path('smartctl')
-    return JSON.parse(new TextDecoder().decode( GLib.spawn_command_line_sync(`'${smartctl}' ${argv} -j`)[1] ))
+const SMARTCTL = GLib.find_program_in_path('smartctl');
+
+function spawnJsonSync(args) {
+    if (!SMARTCTL)
+        return null;
+    let proc = Gio.Subprocess.new([SMARTCTL, ...args, '-j'],
+        Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_PIPE);
+    let [, stdout] = proc.communicate_utf8(null, null);
+    return JSON.parse(stdout);
+}
+
+function spawnJsonAsync(args, cb) {
+    if (!SMARTCTL) {
+        cb(null);
+        return;
+    }
+    let proc;
+    try {
+        proc = Gio.Subprocess.new([SMARTCTL, ...args, '-j'],
+            Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_PIPE);
+    } catch (e) {
+        logError(e, '[FREON] smartctl spawn failed');
+        cb(null);
+        return;
+    }
+    proc.communicate_utf8_async(null, null, (p, res) => {
+        try {
+            let [, stdout] = p.communicate_utf8_finish(res);
+            cb(JSON.parse(stdout));
+        } catch (e) {
+            logError(e, '[FREON] smartctl parse failed');
+            cb(null);
+        }
+    });
 }
 
 export default class SmartctlUtil {
 
     constructor(callback) {
         this._smartDevices = [];
+        this._temps = [];
         try {
-            this._smartDevices = getSmartData("--scan")["devices"]
+            this._smartDevices = spawnJsonSync(["--scan"])["devices"];
         } catch (e) {
             logError(e, '[FREON] Unable to find smart devices');
         }
@@ -30,32 +63,50 @@ export default class SmartctlUtil {
     }
 
     get temp() {
-        return this._smartDevices.map(device => {
-            const info = getSmartData(`--info ${device["name"]}`);
-            if (info["smartctl"]["exit_status"] != 0)
-                return null;
-
-            const attributes = getSmartData(`--attributes ${device["name"]}`);
-            if (attributes["smartctl"]["exit_status"] != 0)
-                return null;
-
-            if(!attributes.temperature) {
-              return null;
-            }
-
-            return {
-                label: info["model_name"],
-                temp: parseFloat(attributes.temperature.current)
-            }
-        }).filter(entry => entry != null);
+        return this._temps;
     }
 
     destroy(callback) {
         this._smartDevices = [];
+        this._temps = [];
     }
 
     execute(callback) {
-        this._updated = true;
+        if (this._smartDevices.length === 0) {
+            this._updated = true;
+            if (callback) callback();
+            return;
+        }
+
+        let pending = this._smartDevices.length;
+        let results = [];
+        const finishOne = (entry) => {
+            if (entry) results.push(entry);
+            if (--pending === 0) {
+                this._temps = results;
+                this._updated = true;
+                if (callback) callback();
+            }
+        };
+
+        for (let device of this._smartDevices) {
+            spawnJsonAsync(["--info", device.name], (info) => {
+                if (!info || info.smartctl.exit_status != 0) {
+                    finishOne(null);
+                    return;
+                }
+                spawnJsonAsync(["--attributes", device.name], (attrs) => {
+                    if (!attrs || attrs.smartctl.exit_status != 0 || !attrs.temperature) {
+                        finishOne(null);
+                        return;
+                    }
+                    finishOne({
+                        label: info.model_name,
+                        temp: parseFloat(attrs.temperature.current)
+                    });
+                });
+            });
+        }
     }
 
 };

--- a/freon@UshakovVasilii_Github.yahoo.com/smartctlUtil.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/smartctlUtil.js
@@ -3,16 +3,7 @@ import GLib from 'gi://GLib';
 
 const SMARTCTL = GLib.find_program_in_path('smartctl');
 
-function spawnJsonSync(args) {
-    if (!SMARTCTL)
-        return null;
-    let proc = Gio.Subprocess.new([SMARTCTL, ...args, '-j'],
-        Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_PIPE);
-    let [, stdout] = proc.communicate_utf8(null, null);
-    return JSON.parse(stdout);
-}
-
-function spawnJsonAsync(args, cb) {
+function spawnJsonAsync(args, cancellable, cb) {
     if (!SMARTCTL) {
         cb(null);
         return;
@@ -26,12 +17,13 @@ function spawnJsonAsync(args, cb) {
         cb(null);
         return;
     }
-    proc.communicate_utf8_async(null, null, (p, res) => {
+    proc.communicate_utf8_async(null, cancellable, (p, res) => {
         try {
             let [, stdout] = p.communicate_utf8_finish(res);
             cb(JSON.parse(stdout));
         } catch (e) {
-            logError(e, '[FREON] smartctl parse failed');
+            if (!e.matches?.(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED))
+                logError(e, '[FREON] smartctl parse failed');
             cb(null);
         }
     });
@@ -42,12 +34,20 @@ export default class SmartctlUtil {
     constructor(callback) {
         this._smartDevices = [];
         this._temps = [];
-        try {
-            this._smartDevices = spawnJsonSync(["--scan"])["devices"];
-        } catch (e) {
-            logError(e, '[FREON] Unable to find smart devices');
-        }
         this._updated = true;
+        this._destroyed = false;
+        this._gen = 0;
+        this._cancellable = new Gio.Cancellable();
+
+        if (SMARTCTL) {
+            spawnJsonAsync(["--scan"], this._cancellable, (data) => {
+                if (this._destroyed) return;
+                if (data && data.devices)
+                    this._smartDevices = data.devices;
+                this._updated = true;
+                if (callback) callback();
+            });
+        }
     }
 
     get available(){
@@ -67,35 +67,45 @@ export default class SmartctlUtil {
     }
 
     destroy(callback) {
+        this._destroyed = true;
+        if (this._cancellable) {
+            this._cancellable.cancel();
+            this._cancellable = null;
+        }
         this._smartDevices = [];
         this._temps = [];
     }
 
     execute(callback) {
-        if (this._smartDevices.length === 0) {
+        if (this._destroyed || this._smartDevices.length === 0) {
             this._updated = true;
             if (callback) callback();
             return;
         }
 
+        const gen = ++this._gen;
         let pending = this._smartDevices.length;
         let results = [];
         const finishOne = (entry) => {
             if (entry) results.push(entry);
             if (--pending === 0) {
-                this._temps = results;
+                if (this._destroyed) return;
+                if (gen === this._gen)
+                    this._temps = results;
                 this._updated = true;
                 if (callback) callback();
             }
         };
 
         for (let device of this._smartDevices) {
-            spawnJsonAsync(["--info", device.name], (info) => {
+            spawnJsonAsync(["--info", device.name], this._cancellable, (info) => {
+                if (this._destroyed) { finishOne(null); return; }
                 if (!info || info.smartctl.exit_status != 0) {
                     finishOne(null);
                     return;
                 }
-                spawnJsonAsync(["--attributes", device.name], (attrs) => {
+                spawnJsonAsync(["--attributes", device.name], this._cancellable, (attrs) => {
+                    if (this._destroyed) { finishOne(null); return; }
                     if (!attrs || attrs.smartctl.exit_status != 0 || !attrs.temperature) {
                         finishOne(null);
                         return;
@@ -109,4 +119,4 @@ export default class SmartctlUtil {
         }
     }
 
-};
+}

--- a/freon@UshakovVasilii_Github.yahoo.com/udisks2.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/udisks2.js
@@ -18,13 +18,17 @@ const UDisksDriveAtaProxy = Gio.DBusProxy.makeProxyWrapper(
 const Async = {
     // mapping will be done in parallel
     map(arr, mapClb /* function(in, successClb)) */, resClb /* function(result) */) {
+        if (arr.length === 0) {
+            resClb([]);
+            return;
+        }
         let counter = arr.length;
         let result = [];
         for (let i = 0; i < arr.length; ++i) {
             mapClb(arr[i], (function(i, newVal) {
                 result[i] = newVal;
                 if (--counter == 0) resClb(result);
-            }).bind(null, i)); // i needs to be bound since it will be changed during the next iteration
+            }).bind(null, i));
         }
     }
 }
@@ -35,12 +39,16 @@ export default class UDisks2 {
     constructor(callback) {
         this._udisksProxies = [];
         this._temps = [];
+        this._cancellable = new Gio.Cancellable();
+        this._destroyed = false;
+        this._updated = false;
         this._get_drive_ata_proxies((proxies) => {
+            if (this._destroyed) return;
             this._udisksProxies = proxies;
             this._refreshTemps();
+            this._updated = true;
             if (callback) callback();
         });
-        this._updated = true;
     }
 
     get available(){
@@ -73,9 +81,10 @@ export default class UDisks2 {
 
     // calls callback with [{ drive: UDisksDriveProxy, ata: UDisksDriveAtaProxy }, ... ] for every drive that implements both interfaces
     _get_drive_ata_proxies(callback) {
-        Gio.DBusObjectManagerClient.new(Gio.DBus.system, 0, "org.freedesktop.UDisks2", "/org/freedesktop/UDisks2", null, null, function(src, res) {
+        Gio.DBusObjectManagerClient.new(Gio.DBus.system, 0, "org.freedesktop.UDisks2", "/org/freedesktop/UDisks2", null, this._cancellable, (src, res) => {
             try {
                 let objMgr = Gio.DBusObjectManagerClient.new_finish(res); //might throw
+                this._objMgr = objMgr;
 
                 let objPaths = objMgr.get_objects().filter(function(o) {
                     return o.get_interface("org.freedesktop.UDisks2.Drive") != null
@@ -83,43 +92,58 @@ export default class UDisks2 {
                 }).map(function(o) { return o.get_object_path() });
 
                 // now create the proxy objects, log and ignore every failure
-                Async.map(objPaths, function(obj, callback) {
+                Async.map(objPaths, (obj, mapCb) => {
+                    if (this._destroyed) {
+                        mapCb(null);
+                        return;
+                    }
                     // create the proxies object
-                    let driveProxy = new UDisksDriveProxy(Gio.DBus.system, "org.freedesktop.UDisks2", obj, function(res, error) {
-                        if (error) { //very unlikely - we even checked the interfaces before!
+                    let driveProxy = new UDisksDriveProxy(Gio.DBus.system, "org.freedesktop.UDisks2", obj, (res, error) => {
+                        if (error) {
                             logError(error, '[FREON] Could not create proxy on ' + obj);
-                            callback(null);
+                            mapCb(null);
                             return;
                         }
-                        let ataProxy = new UDisksDriveAtaProxy(Gio.DBus.system, "org.freedesktop.UDisks2", obj, function(res, error) {
+                        let ataProxy = new UDisksDriveAtaProxy(Gio.DBus.system, "org.freedesktop.UDisks2", obj, (res, error) => {
                             if (error) {
                                 logError(error, '[FREON] Could not create proxy on ' + obj);
-                                callback(null);
+                                mapCb(null);
                                 return;
                             }
 
-                            callback({ drive: driveProxy, ata: ataProxy });
-                        });
-                    });
+                            mapCb({ drive: driveProxy, ata: ataProxy });
+                        }, this._cancellable);
+                    }, this._cancellable);
                 }, function(proxies) {
-                    // filter out failed attempts == null values
                     callback(proxies.filter(function(a) { return a != null; }));
                 });
             } catch (e) {
-                logError(e, '[FREON] Could not find UDisks2 objects');
+                if (!e.matches?.(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED))
+                    logError(e, '[FREON] Could not find UDisks2 objects');
+                callback([]);
             }
         });
     }
 
     destroy(callback) {
+        this._destroyed = true;
+        if (this._cancellable) {
+            this._cancellable.cancel();
+            this._cancellable = null;
+        }
         this._udisksProxies = [];
         this._temps = [];
+        this._objMgr = null;
     }
 
     execute(callback) {
+        if (this._destroyed) {
+            if (callback) callback();
+            return;
+        }
         this._refreshTemps();
         this._updated = true;
         if (callback) callback();
     }
 
-};
+}

--- a/freon@UshakovVasilii_Github.yahoo.com/udisks2.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/udisks2.js
@@ -34,9 +34,11 @@ export default class UDisks2 {
 
     constructor(callback) {
         this._udisksProxies = [];
+        this._temps = [];
         this._get_drive_ata_proxies((proxies) => {
             this._udisksProxies = proxies;
-            callback();
+            this._refreshTemps();
+            if (callback) callback();
         });
         this._updated = true;
     }
@@ -53,9 +55,12 @@ export default class UDisks2 {
         this._updated = updated;
     }
 
-    // creates a list of sensor objects from the list of proxies given
     get temp() {
-        return this._udisksProxies.filter(function(proxy) {
+        return this._temps;
+    }
+
+    _refreshTemps() {
+        this._temps = this._udisksProxies.filter(function(proxy) {
             // 0K means no data available
             return proxy.ata.SmartTemperature > 0;
         }).map(function(proxy) {
@@ -108,10 +113,13 @@ export default class UDisks2 {
 
     destroy(callback) {
         this._udisksProxies = [];
+        this._temps = [];
     }
 
     execute(callback) {
+        this._refreshTemps();
         this._updated = true;
+        if (callback) callback();
     }
 
 };


### PR DESCRIPTION
## Summary

20 small commits hardening Freon's extension lifecycle, async IO, subprocess security, and forward compatibility with GNOME Shell 45–50. All changes preserve existing behavior; nothing user-visible was added or removed.

## What changed

### Correctness / silent-failure fixes
- `extension.js` watched the wrong schema key for the Bumblebee+Nvidia provider switch (`use-gpu-nvidiabumblebee` vs the real `use-gpu-bumblebeenvidia`), so toggling the switch never restarted the utility.
- `bumblebeeNvidiaUtil.js` parsed the lock-config and the `nvidia-smi -L` output by stringifying a byte buffer or the 4-element `spawn_command_line_sync` tuple — both always produced rubbish and the GPU label was never detected. Decoded via `TextDecoder` and made the spawn async.
- Same `[ok, Uint8Array]` stringification bug fixed in `hddtempUtil.js` (`/proc/<pid>/cmdline` parse).
- `extension.js` computed the temperature mean inside a loop that reset its accumulators on every iteration, so the displayed average reflected only the last reading. Hoisted the accumulators.
- `prefs.js` used `Gio.SettingsBindFlags.NO_SENSETIVITY` (typo of `NO_SENSITIVITY`); the undefined symbol silently fell back to `DEFAULT`. Fixed on all three ComboRow bindings.
- `bumblebeeNvidiaUtil.js` referenced `_()` without importing `gettext`, so the fallback label path threw `ReferenceError` for users with Bumblebee enabled but no detected GPU name. Imported `gettext`.

### Lifecycle / leak hardening
- Added `Gio.Cancellable` plus a `_destroyed` guard to every async path that previously passed `null` for its cancellable: `CommandLineUtil`, `NvidiaUtil`, `UDisks2`, `BumblebeeNvidiaUtil._detectLabel`. Pending subprocess and DBus callbacks now bail out instead of writing to a torn-down menu, and the `FreonMenuButton` is no longer retained through in-flight Promises across enable/disable cycles.
- `UDisks2` constructor now keeps `_updated=false` until proxies arrive (previously a flag race caused the first poll cycle to render an empty disk-temp section).
- `bumblebeeNvidiaUtil.destroy()` now cancels the `Gio.FileMonitor` in addition to disconnecting its `'changed'` signal — previously the inotify watch leaked across reloads.
- One-shot panel-position timer in `extension.js` now zeros its ID inside the callback and the cleanup path guards `GLib.Source.remove`; every other timer ID is also zeroed after removal to make double-teardown safe.

### Subprocess / IO — security and main-loop blocking
- `pkexecUtil.js` ran the polkit `install` step through `GLib.spawn_command_line_sync` with the extension dir interpolated into a shell command (shell-injection vector on paths containing whitespace or metacharacters, and a sync main-loop block while pkexec showed its auth dialog). Switched to `Gio.Subprocess.new` argv form. Also dropped the JS-stack heuristic that tried to discover the extension dir — it does not match ESM frames in modern GJS — and now takes the directory as a constructor argument forwarded from `extension.js`.
- `batteryUtil.js` was shelling out to `find` and `cat` with battery paths interpolated into the command string. Replaced with `Gio.File.enumerate_children` + `GLib.file_get_contents` directly against `/sys/class/power_supply/`.
- `smartctlUtil.js`, `nvmecliUtil.js`, `hddtempUtil.js` constructors ran one to four synchronous `spawn_command_line_sync` calls on the main loop (smartctl `--scan`, nvme `list`, hddtemp probe, systemctl/pidof), blocking the GNOME Shell compositor for one to three seconds during extension enable or when toggling the provider switch. Every initial probe is now async (`Gio.Subprocess.communicate_utf8_async` with the per-utility cancellable).
- All sensor utilities now use the argv form of `Gio.Subprocess.new` rather than interpolating device names into a shell string.

### Race-condition hardening
- Settings changes can fire `_querySensors` while a previous batch is still in flight in `smartctl`/`nvme`. Added a generation counter so only the most recent batch publishes its results.

### Forward compatibility (GNOME Shell 50)
- Replaced every `someMenuItem.actor.add_child(...)` call with `someMenuItem.add_child(...)`. `.actor` is a back-compat shim on `PopupBaseMenuItem`; it still works on 45–50 but is slated for removal.
- Replaced the hardcoded `insert_child_at_index(status, 4)` for the temperature submenu's status label with `insert_child_below(status, _triangleBin)` and a fallback, removing the implicit dependency on `PopupSubMenuMenuItem`'s internal child ordering.

### Performance
- `smartctlUtil` and `nvmecliUtil` used to run their per-device subprocess calls synchronously inside the `temp` getter (called from the 250ms UI redraw timer). Now they run in parallel inside `execute()` via async subprocess, results are cached, and `temp` returns the cache.
- `udisks2.js` `temp` getter no longer rebuilds the filtered/mapped sensor list on every redraw; built once in `execute()`.
- `sensorsUtil.js` `lm_sensors` JSON was parsed once but then walked six times (one per getter) re-running the family/key regexes. Replaced with a single pass in `execute()` that builds all six groups; getters return cached arrays.
- `extension.js` `_updateDisplay` hoisted five `settings.get_boolean` calls (previously read tens of times per render) to locals; `_fixNames` uses a `Set` instead of `Array.indexOf` for the seen-names check; idle UI timer relaxed from 250ms to 500ms; module-level regex for debug stack-trace parsing.

### Schema / prefs hygiene
- Fixed three copy-paste bugs in the gschema (the `show-temperature` summary said "Show RPM on Panel"; two spelling fixes).
- Added `<range min="1" max="600"/>` to `update-time` so a manually set 0 in dconf cannot busy-loop the shell. The extension also clamps at runtime as a defense-in-depth.
- Removed the dead schema key `exec-method-freeipmi` (replaced long ago by the integer `freeimpi-selected`).
- `prefs.js`: wrapped `Gtk.StringList` entries with `_()` so they translate; `_addSwitch` now omits the `subtitle` field when no help text is supplied (instead of passing an empty string that Adwaita renders as a visible empty subtitle row); subtitles, when provided, also go through `_()`.

## Why a single PR

The changes are small individually but mutually reinforcing: the lifecycle/cancellable work and the async-constructor work share machinery, the security and perf fixes in `smartctl`/`nvme` touch the same files, and the forward-compat `.actor` removal had to land before the temperature-submenu status label move. Splitting would have made review harder, not easier.

## Test plan

- [x] Each commit syntax-checked with `node --check` (GJS-compatible).
- [x] `glib-compile-schemas` clean.
- [x] Memory leak check on Wayland: 40 enable/disable cycles. Per-cycle RSS growth (~850 KB) matches a control extension (Caffeine) on the same shell, indicating the growth is GNOME Shell internal (JS heap warmup, class metadata cache) rather than freon-specific.
- [x] All `Gio.Subprocess` calls verified to take the argv form (no `spawn_command_line_sync` of interpolated strings remaining).
- [ ] Visual smoke test on each declared shell version (45/46/47/48/49/50) — only tested on 50.

## What is NOT in this PR

- No UI/feature changes.
- No new sensor providers.
- No translation updates.

## Breaking changes

None expected. The `<range>` constraint on `update-time` is a soft change: out-of-range dconf values are clamped on read (and at runtime). The removed `exec-method-freeipmi` schema key was never read by any code path in master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)