### PR TITLE
fix(gpu): correct schema key for Bumblebee+Nvidia setting watcher

### DIFF
--- a/freon@UshakovVasilii_Github.yahoo.com/extension.js
+++ b/freon@UshakovVasilii_Github.yahoo.com/extension.js
@@ -145,7 +145,7 @@ class FreonMenuButton extends PanelMenu.Button {
         this._addSettingChangedSignal('show-battery-stats', this._batteryUtilityChanged.bind(this));
 
         this._addSettingChangedSignal('use-gpu-nvidia', this._nvidiaUtilityChanged.bind(this));
-        this._addSettingChangedSignal('use-gpu-nvidiabumblebee', this._nvidiabumblebeeUtilityChanged.bind(this));
+        this._addSettingChangedSignal('use-gpu-bumblebeenvidia', this._nvidiabumblebeeUtilityChanged.bind(this));
         this._addSettingChangedSignal('use-gpu-aticonfig', this._aticonfigUtilityChanged.bind(this));
 
         this._addSettingChangedSignal('use-drive-udisks2', this._udisks2UtilityChanged.bind(this));


### PR DESCRIPTION
## Summary

The settings watcher for the Bumblebee+Nvidia provider switch was connected to a key that does not exist in the schema (`use-gpu-nvidiabumblebee`); the real key, used everywhere else in the codebase and in `prefs.js`, is `use-gpu-bumblebeenvidia`.

Effect: toggling the "Bumblebee + Nvidia" switch in preferences never fired `_nvidiabumblebeeUtilityChanged`, so the utility was never (re)started when the user enabled the switch and never destroyed when they disabled it. A restart of GNOME Shell was needed for the toggle to take effect.

## Diff

```diff
-        this._addSettingChangedSignal('use-gpu-nvidiabumblebee', this._nvidiabumblebeeUtilityChanged.bind(this));
+        this._addSettingChangedSignal('use-gpu-bumblebeenvidia', this._nvidiabumblebeeUtilityChanged.bind(this));
```

One-line correctness fix; no behavior change other than the toggle actually working.

## Verification

- The init path at `extension.js:386-387` already reads the correct key (`use-gpu-bumblebeenvidia`) — so the initial state on enable was right; only the live-change watcher was wrong.
- `prefs.js:134` binds the switch row to `use-gpu-bumblebeenvidia`.
- `schemas/org.gnome.shell.extensions.sensors.gschema.xml:114` defines `use-gpu-bumblebeenvidia`. There is no `use-gpu-nvidiabumblebee` key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)